### PR TITLE
fix: 파이프라인 오타 수정 및 matplotlib Agg 백엔드 사용

### DIFF
--- a/src/capture/scene_visualizer.py
+++ b/src/capture/scene_visualizer.py
@@ -10,6 +10,8 @@ Note: 2차 정제(dedupe_threshold)는 '저장된 이미지 간' 비교로,
       프레임 간 diff_score와는 다른 측정값입니다.
 """
 
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import numpy as np

--- a/src/run_video_pipeline.py
+++ b/src/run_video_pipeline.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from concurrent.futures import ThreadPoolEx
+from concurrent.futures import ThreadPoolExecutor
 import sys
-import timeecutor
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -223,7 +223,7 @@ def _run_fusion_pipeline(config_path: Path, *, limit: Optional[int], dry_run: bo
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="비디오 1개 입력으로 end-to-end 요약 실행")
     parser.add_argument("--video", required=True, help="입력 비디오 파일 경로")
-    parser.add_argument("--output-base", default="src/data/output", help="동영상별 outputs 베이스 디렉토리")
+    parser.add_argument("--output-base", default="data/outputs", help="동영상별 outputs 베이스 디렉토리")
     parser.add_argument("--stt-backend", choices=["clova"], default="clova", help="STT 백엔드")
     parser.add_argument("--parallel", action=argparse.BooleanOptionalAction, default=True, help="STT+Capture 병렬 실행")
     parser.add_argument("--capture-threshold", type=float, default=3.0, help="장면 전환 감지 임계값")


### PR DESCRIPTION
## 변경 사항
- `src/run_video_pipeline.py`에서 오타로 잘못 import되던 `ThreadPoolEx`/`timeecutor`를 `ThreadPoolExecutor`/`time`으로 수정하여 실행 오류를 제거했습니다.
- `src/capture/scene_visualizer.py`에서 Matplotlib 백엔드를 `Agg`로 고정해, 병렬 실행 시 Tk 객체가 worker thread에서 생성/정리되며 발생하는 `main thread is not in main loop` 및 `Tcl_AsyncDelete` 에러로 파이프라인이 중간에 종료되는 문제를 방지했습니다.
- `src/run_video_pipeline.py`의 기본 출력 경로를 `data/outputs`로 변경해, 기본 실행 시 결과가 `src` 아래가 아닌 프로젝트 `data/outputs`에 저장되도록 했습니다.

## 변경 유형
- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Style

## 테스트
- [x] 로컬에서 테스트 완료
