### PR TITLE
Refactor: Judge 결과 통합 및 출력 옵션 정리

### DIFF
--- a/src/judge/judge.py
+++ b/src/judge/judge.py
@@ -1,12 +1,12 @@
 # Usage:
 # python src/judge/judge.py --config src/fusion/config.yaml
-# python src/judge/judge.py --config src/fusion/config.yaml --limit 2 --return-reasons
+# python src/judge/judge.py --config src/fusion/config.yaml --limit 2 --write-outputs
 #
 # Inputs:
 # - segments_units.jsonl (default: {output_root}/fusion/segments_units.jsonl)
 # - segment_summaries.jsonl (default: {output_root}/fusion/segment_summaries.jsonl)
 #
-# Outputs:
+# Outputs (when --write-outputs):
 # - judge_report.json (default: {output_root}/fusion/judge/judge_report.json)
 # - judge_segment_reports.jsonl (default: {output_root}/fusion/judge/judge_segment_reports.jsonl)
 #
@@ -17,10 +17,10 @@
 # --output-segments PATH
 # --batch-size N
 # --workers N
+# --write-outputs
 # --verbose
 # --limit N
 # --json-repair-attempts N
-# --return-reasons (or env JUDGE_RETURN_REASONS=1)
 #
 """LLM judge for segment summaries.
 
@@ -51,7 +51,7 @@ from src.fusion.config import ConfigBundle
 from src.fusion.io_utils import read_jsonl, write_json, write_jsonl
 
 
-PROMPT_VERSION = "judge_v3"
+PROMPT_VERSION = "judge_v4"
 JUDGE_TEMPERATURE = 0.2
 MAX_SCORE = 10
 _THREAD_LOCAL = threading.local()
@@ -228,14 +228,6 @@ def _repair_prompt(bad_json: str) -> str:
     )
 
 
-def _env_flag(name: str, default: bool = False) -> bool:
-    """Parse a boolean environment variable."""
-    value = os.getenv(name)
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
 def _chunked(items: List[Dict[str, Any]], size: int) -> List[List[Dict[str, Any]]]:
     """Split a list into fixed-size chunks."""
     if size <= 0:
@@ -250,7 +242,6 @@ def _evaluate_batch(
     batch: List[Dict[str, Any]],
     batch_index: int,
     batch_total: int,
-    return_reasons: bool,
     json_repair_attempts: int,
     verbose: bool,
 ) -> Dict[int, Dict[str, Any]]:
@@ -259,7 +250,7 @@ def _evaluate_batch(
         print(f"[JUDGE] batch {batch_index}/{batch_total} start (segments={seg_ids})")
     started = time.perf_counter()
     client_bundle = _get_thread_client_bundle(config)
-    prompt = _build_prompt(batch, return_reasons)
+    prompt = _build_prompt(batch)
     llm_text = _run_with_retries(
         client_bundle,
         prompt,
@@ -339,7 +330,7 @@ def _merge_segments(
     return matched, missing_units, missing_summaries
 
 
-def _build_prompt(segments_payload: List[Dict[str, Any]], include_reasons: bool) -> str:
+def _build_prompt(segments_payload: List[Dict[str, Any]]) -> str:
     """Build the LLM judge prompt."""
     lines = [
         "You are a strict evaluator for segment summaries.",
@@ -414,33 +405,20 @@ def _build_prompt(segments_payload: List[Dict[str, Any]], include_reasons: bool)
         "- Return a JSON array only. No markdown or extra text.",
         "- Use integer scores only (0-10).",
         "- Do not output final; it will be computed downstream.",
+        "- Include feedback as a single Korean sentence per segment.",
+        "- feedback should mention the most important issue or strength.",
+        "- Do not mention multimodal_use in feedback unless it is the sole critical issue.",
+        "- If there are no issues, say that it is strong (e.g., '전반적으로 우수').",
     ]
-    if include_reasons:
-        lines.append("- Include reasons_ko as 4 short Korean items in this order:")
-        lines.append("  1) 근거: groundedness 판단 이유")
-        lines.append("  2) 규칙: compliance 판단 이유")
-        lines.append("  3) 노트: note_quality 판단 이유")
-        lines.append("  4) 시각: multimodal_use 판단 이유")
-        lines.append("- Each item should be 1 sentence and start with the label (근거/규칙/노트/시각).")
-        lines.append(
-            "- Make reasons_ko concrete: mention 1-2 specific signals (e.g., banned word, missing"
-            " definitions, missing role A/B/C, unsupported claim)."
-        )
-        lines.append(
-            "- For 규칙: if banned words are the only issue, say so; if no issues, say '그 외 위반 없음'."
-        )
-    else:
-        lines.append("- Do NOT include reasons_ko.")
 
     lines.append("Output format for each segment:")
     lines.append("{")
     lines.append('  "segment_id": int,')
     lines.append(
         '  "scores": {"groundedness": int, "compliance": int, '
-        '"note_quality": int, "multimodal_use": int}'
+        '"note_quality": int, "multimodal_use": int},'
     )
-    if include_reasons:
-        lines.append('  ,"reasons_ko": ["..."]')
+    lines.append('  "feedback": "한 줄 피드백"')
     lines.append("}")
     lines.extend(
         [
@@ -452,7 +430,7 @@ def _build_prompt(segments_payload: List[Dict[str, Any]], include_reasons: bool)
     return "\n".join(lines)
 
 
-def _build_response_schema(include_reasons: bool) -> Dict[str, Any]:
+def _build_response_schema() -> Dict[str, Any]:
     """Return a response schema for Gemini."""
     score_schema = {
         "type": "object",
@@ -466,18 +444,13 @@ def _build_response_schema(include_reasons: bool) -> Dict[str, Any]:
     }
     item_schema: Dict[str, Any] = {
         "type": "object",
-        "required": ["segment_id", "scores"],
+        "required": ["segment_id", "scores", "feedback"],
         "properties": {
             "segment_id": {"type": "integer"},
             "scores": score_schema,
+            "feedback": {"type": "string"},
         },
     }
-    if include_reasons:
-        item_schema["required"].append("reasons_ko")
-        item_schema["properties"]["reasons_ko"] = {
-            "type": "array",
-            "items": {"type": "string"},
-        }
     return {"type": "array", "items": item_schema}
 
 
@@ -490,17 +463,12 @@ def _clamp_score(value: Any, max_score: int = MAX_SCORE) -> int:
     return max(0, min(max_score, score))
 
 
-def _normalize_str_list(value: Any) -> List[str]:
-    """Normalize a value into a list of non-empty strings."""
-    if value is None:
-        return []
-    items = value if isinstance(value, list) else [value]
-    normalized: List[str] = []
-    for item in items:
-        text = str(item or "").strip()
-        if text:
-            normalized.append(text)
-    return normalized
+def _normalize_feedback(value: Any) -> str:
+    """Normalize a feedback string into a single line."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return " ".join(text.split())
 
 
 def _compute_final_score(groundedness: int, compliance: int, note_quality: int) -> float:
@@ -522,10 +490,15 @@ def run_judge(
     workers: int,
     json_repair_attempts: int,
     limit: Optional[int],
-    return_reasons: bool,
     verbose: bool,
+    write_outputs: bool,
 ) -> Dict[str, Any]:
-    """Run the judge and write JSON outputs."""
+    """Run the judge and optionally write JSON outputs.
+
+    Returns:
+        report: aggregate score report
+        segment_reports: per-segment score/feedback list
+    """
     segments_units = _load_segments_units(segments_units_path)
     segment_summaries = _load_segment_summaries(segment_summaries_path)
     matched_ids, missing_units, missing_summaries = _merge_segments(
@@ -550,7 +523,7 @@ def run_judge(
             }
         )
 
-    response_schema = _build_response_schema(return_reasons)
+    response_schema = _build_response_schema()
 
     llm_results: Dict[int, Dict[str, Any]] = {}
     batches = _chunked(payloads, batch_size)
@@ -567,7 +540,6 @@ def run_judge(
                     batch=batch,
                     batch_index=idx,
                     batch_total=len(batches),
-                    return_reasons=return_reasons,
                     json_repair_attempts=json_repair_attempts,
                     verbose=verbose,
                 )
@@ -583,7 +555,6 @@ def run_judge(
                     batch=batch,
                     batch_index=idx,
                     batch_total=len(batches),
-                    return_reasons=return_reasons,
                     json_repair_attempts=json_repair_attempts,
                     verbose=verbose,
                 )
@@ -609,13 +580,13 @@ def run_judge(
         note_quality = _clamp_score(llm_scores.get("note_quality"))
         multimodal_use = _clamp_score(llm_scores.get("multimodal_use"))
         final_score = _compute_final_score(groundedness, compliance, note_quality)
-        reasons_ko = (
-            _normalize_str_list(llm_item.get("reasons_ko")) if return_reasons else []
-        )
+        feedback = _normalize_feedback(llm_item.get("feedback"))
+        if not feedback:
+            raise ValueError(f"segment_id={seg_id} feedback is empty.")
 
         segment_reports.append(
             {
-                "schema_version": 1,
+                "schema_version": 2,
                 "segment_id": seg_id,
                 "scores": {
                     "groundedness": groundedness,
@@ -624,7 +595,7 @@ def run_judge(
                     "multimodal_use": multimodal_use,
                     "final": final_score,
                 },
-                "reasons_ko": reasons_ko,
+                "feedback": feedback,
                 "meta": {
                     "model": config.raw.llm_gemini.model,
                     "prompt_version": PROMPT_VERSION,
@@ -645,7 +616,7 @@ def run_judge(
     avg_final = round(sum(final_scores) / len(final_scores), 2)
 
     report: Dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": 2,
         "score_scale": {"min": 0, "max": MAX_SCORE},
         "scores": {
             "groundedness": avg_groundedness,
@@ -662,16 +633,17 @@ def run_judge(
         "meta": {
             "model": config.raw.llm_gemini.model,
             "prompt_version": PROMPT_VERSION,
-            "return_reasons": return_reasons,
             "generated_at_utc": _utc_now_iso(),
-            "segments_units_path": str(segments_units_path),
-            "segment_summaries_path": str(segment_summaries_path),
         },
     }
 
-    write_json(output_report_path, report)
-    write_jsonl(output_segments_path, segment_reports)
-    return report
+    result = {"report": report, "segment_reports": segment_reports}
+    if write_outputs:
+        report["meta"]["segments_units_path"] = str(segments_units_path)
+        report["meta"]["segment_summaries_path"] = str(segment_summaries_path)
+        write_json(output_report_path, report)
+        write_jsonl(output_segments_path, segment_reports)
+    return result
 
 
 def _resolve_path(explicit: Optional[str], fallback: Path) -> Path:
@@ -698,17 +670,17 @@ def main() -> None:
     parser.add_argument("--output-segments", default=None, help="output segment reports JSONL path")
     parser.add_argument("--batch-size", type=int, default=3, help="LLM batch size")
     parser.add_argument("--workers", type=int, default=1, help="parallel LLM requests")
+    parser.add_argument(
+        "--write-outputs",
+        action="store_true",
+        help="write judge_report.json and judge_segment_reports.jsonl",
+    )
     parser.add_argument("--limit", type=int, default=None, help="limit segment count")
     parser.add_argument("--json-repair-attempts", type=int, default=1)
     parser.add_argument(
         "--verbose",
         action="store_true",
         help="print batch-level progress logs",
-    )
-    parser.add_argument(
-        "--return-reasons",
-        action="store_true",
-        help="include reasons_ko in LLM output",
     )
     args = parser.parse_args()
 
@@ -724,10 +696,8 @@ def main() -> None:
     output_report_path = _resolve_path(args.output_report, default_report)
     output_segments_path = _resolve_path(args.output_segments, default_segments_report)
 
-    return_reasons = args.return_reasons or _env_flag("JUDGE_RETURN_REASONS", False)
-
     start_time = time.perf_counter()
-    report = run_judge(
+    result = run_judge(
         config=config,
         segments_units_path=segments_units_path,
         segment_summaries_path=segment_summaries_path,
@@ -737,11 +707,15 @@ def main() -> None:
         workers=args.workers,
         json_repair_attempts=args.json_repair_attempts,
         limit=args.limit,
-        return_reasons=return_reasons,
         verbose=args.verbose,
+        write_outputs=args.write_outputs,
     )
+    report = result["report"]
     elapsed_sec = time.perf_counter() - start_time
-    print(f"[OK] judge report: {output_report_path}")
+    if args.write_outputs:
+        print(f"[OK] judge report: {output_report_path}")
+    else:
+        print("[OK] judge outputs skipped (write_outputs=false)")
     print(f"[OK] avg final score: {report['scores']['final']}")
     print(f"[OK] elapsed: {elapsed_sec:.2f}s")
 


### PR DESCRIPTION
## 변경 내용
- judge.json만 출력 되도록 수정
- judge.json에 feedback seg별로 text한줄씩 나오도록 수정
    - 나중에 요약 LLM에서는 json파일 읽어서 하는것으로 알고있어서 이렇게 수정

## 변경 사항
- run_judge에 write_outputs 플래그 추가 및 report/segment_reports 반환 구조 분리
- reasons_ko 대신 한 줄 feedback으로 변경하고 프롬프트에서 multimodal 언급 최소화
- ADK judge는 judge.json만 생성하도록 정리하고 include_segments 옵션 추가

## 변경 유형
- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Style

## 관련 이슈
Closes #50

## 테스트
- [X] 로컬에서 테스트 완료

## 체크리스트
- [X] 코드 스타일 가이드라인 준수
- [X] 기존 테스트 통과 확인
