### PR TITLE
fix: main() 함수 내 args 참조 버그 수정

### DIFF
--- a/src/run_video_pipeline.py
+++ b/src/run_video_pipeline.py
@@ -868,7 +868,7 @@ def main() -> None:
         raise FileNotFoundError(f"비디오 파일을 찾을 수 없습니다: {video_path}")
 
     repo_root = ROOT
-    output_base = (repo_root / Path(output_base)).resolve()
+    output_base = (repo_root / Path(args.output_base)).resolve()
     video_name = _sanitize_video_name(video_path.stem)
     video_root = output_base / video_name
     video_root.mkdir(parents=True, exist_ok=True)
@@ -887,15 +887,15 @@ def main() -> None:
     run_args = {
         "video": str(video_path),
         "output_base": str(output_base),
-        "stt_backend": stt_backend,
-        "parallel": parallel,
-        "capture_threshold": capture_threshold,
-        "capture_dedupe_threshold": capture_dedupe_threshold,
-        "capture_min_interval": capture_min_interval,
-        "capture_verbose": capture_verbose,
-        "vlm_batch_size": vlm_batch_size,
-        "limit": limit,
-        "dry_run": dry_run,
+        "stt_backend": args.stt_backend,
+        "parallel": args.parallel,
+        "capture_threshold": args.capture_threshold,
+        "capture_dedupe_threshold": args.capture_dedupe_threshold,
+        "capture_min_interval": args.capture_min_interval,
+        "capture_verbose": args.capture_verbose,
+        "vlm_batch_size": args.vlm_batch_size,
+        "limit": args.limit,
+        "dry_run": args.dry_run,
     }
     run_meta: Dict[str, Any] = {
         "schema_version": 2,
@@ -1099,23 +1099,6 @@ def main() -> None:
         _write_json(run_meta_path, run_meta)
         print(f"\n❌ Pipeline failed: {exc}")
         raise
-
-
-def main() -> None:
-    args = parse_args()
-    run_pipeline(
-        video=args.video,
-        output_base=args.output_base,
-        stt_backend=args.stt_backend,
-        parallel=args.parallel,
-        capture_threshold=args.capture_threshold,
-        capture_dedupe_threshold=args.capture_dedupe_threshold,
-        capture_min_interval=args.capture_min_interval,
-        capture_verbose=args.capture_verbose,
-        vlm_batch_size=args.vlm_batch_size,
-        limit=args.limit,
-        dry_run=args.dry_run,
-    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 문제
`run_video_pipeline.py` 실행 시 다음 에러 발생:
- `NameError: name 'run_pipeline' is not defined`
- `UnboundLocalError: local variable 'output_base' referenced before assignment`

## 원인
1. `main()` 함수가 중복 정의됨 (라인 862, 1104)
2. 두 번째 `main()`이 존재하지 않는 `run_pipeline` 함수를 호출
3. 첫 번째 `main()` 내에서 `args.` 접두사 없이 변수 참조

## 해결
- 중복 정의된 두 번째 `main()` 함수 제거
- `output_base`, `stt_backend` 등 변수에 `args.` 접두사 추가

## 테스트
✅ 파이프라인 정상 실행 확인