### PR TITLE
[Feature] STT 모듈: stt_XXX 고유 ID 생성 기능 추가

### DIFF
--- a/src/audio/clova_stt.py
+++ b/src/audio/clova_stt.py
@@ -14,6 +14,7 @@ ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
 def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[Dict[str, Any]]:
     """Clova 응답에서 세그먼트 목록을 추출해 표준 형태로 정리한다."""
     segments_out: List[Dict[str, Any]] = []
+    segment_index = 0
     for segment in raw.get("segments", []):
         if not isinstance(segment, dict):
             continue
@@ -23,6 +24,7 @@ def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[
         text = text.strip()
         if not text:
             continue
+        segment_index += 1
         try:
             start_ms = int(round(float(segment.get("start"))))
         except (TypeError, ValueError):
@@ -35,6 +37,7 @@ def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[
             "start_ms": start_ms,
             "end_ms": end_ms,
             "text": text,
+            "id": f"stt_{segment_index:03d}",
         }
         if include_confidence:
             try:

--- a/src/audio/whisper_stt.py
+++ b/src/audio/whisper_stt.py
@@ -60,16 +60,19 @@ class WhisperSTTClient:
         )
 
         segments_out: List[Dict[str, Any]] = []
+        segment_index = 0
         for segment in result.get("segments", []):
             if not isinstance(segment, dict):
                 continue
             text = str(segment.get("text", "")).strip()
             if not text:
                 continue
+            segment_index += 1
             item: Dict[str, Any] = {
                 "start_ms": int(round(float(segment.get("start", 0.0)) * 1000)),
                 "end_ms": int(round(float(segment.get("end", 0.0)) * 1000)),
                 "text": text,
+                "id": f"stt_{segment_index:03d}",
             }
             if include_confidence:
                 confidence = _segment_confidence(segment)


### PR DESCRIPTION
## 요약
STT 모듈에 고유 ID 생성 기능을 추가합니다. 각 STT 세그먼트에 `stt_XXX` 형식의 ID가 부여되어 이후 파이프라인에서 추적이 가능합니다.

## 변경 사항

### src/audio/clova_stt.py
- `segment_index` 카운터 추가
- 각 세그먼트 출력에 `"id": "stt_XXX"` 필드 추가

### src/audio/whisper_stt.py
- `segment_index` 카운터 추가
- 각 세그먼트 출력에 `"id": "stt_XXX"` 필드 추가

---

## Summary
Add unique ID generation to STT modules. Each STT segment now has an `stt_XXX` format ID for tracking in the pipeline.

## Changes

### src/audio/clova_stt.py
- Add `segment_index` counter for unique ID generation
- Add `"id"` field with format `"stt_XXX"` to each segment output

### src/audio/whisper_stt.py
- Add `segment_index` counter for unique ID generation
- Add `"id"` field with format `"stt_XXX"` to each segment output