### PR TITLE
[Feature] Capture 모듈: cap_XXX 고유 ID 생성 + capture.json 이름 변경

### DIFF
--- a/src/capture/process_content.py
+++ b/src/capture/process_content.py
@@ -1,5 +1,5 @@
 """
-캡쳐 단계에서 비디오 1건을 처리해 슬라이드 캡쳐와 manifest.json을 만든다.
+캡쳐 단계에서 비디오 1건을 처리해 슬라이드 캡쳐와 capture.json을 만든다.
 run_video_pipeline에서 호출되며 설정은 config/capture/settings.yaml에서 로드한다.
 """
 
@@ -57,7 +57,11 @@ def process_single_video_capture(
     slides = extractor.process(video_name=video_name)
     elapsed = time.time() - start_time
 
-    manifest_path = output_root / "manifest.json"
+    # Assign IDs
+    for idx, slide in enumerate(slides, 1):
+        slide["id"] = f"cap_{idx:03d}"
+
+    manifest_path = output_root / "capture.json"
     with manifest_path.open("w", encoding="utf-8") as handle:
         json.dump(slides, handle, ensure_ascii=False, indent=2)
 


### PR DESCRIPTION
## 요약
Capture 모듈에 고유 ID 생성 기능을 추가합니다. 각 슬라이드에 `cap_XXX` 형식의 ID가 부여되며, 출력 파일명이 `manifest.json`에서 `capture.json`으로 변경됩니다.

## 변경 사항

### src/capture/process_content.py
- 슬라이드 추출 후 ID 할당 루프 추가
- 각 슬라이드에 `"id": "cap_XXX"` 필드 추가
- 출력 파일명 변경: `manifest.json` → `capture.json`

---

## Summary
Add unique ID generation to Capture module. Each slide now has a `cap_XXX` format ID, and output file renamed from `manifest.json` to `capture.json`.

## Changes

### src/capture/process_content.py
- Add ID assignment loop after slide extraction
- Each slide now has `"id"` field with format `"cap_XXX"`
- Rename output file: `manifest.json` → `capture.json`