### PR TITLE
[Feature] Fusion 모듈: ID 보존 기능 및 렌더러 개선

### DIFF
--- a/src/fusion/config.py
+++ b/src/fusion/config.py
@@ -91,12 +91,25 @@ class LlmGeminiConfig(BaseModel):
     vertex_ai: VertexAiConfig
 
 
+class RenderGroupsConfig(BaseModel):
+    """마크다운 렌더링의 그룹별 표시 순서와 헤더를 설정한다."""
+    model_config = ConfigDict(extra="forbid")
+
+    order: List[str] = ["direct", "background", "inferred"]
+    headers: dict = Field(default_factory=lambda: {
+        "direct": "핵심 내용 (Direct / Recall)",
+        "background": "배경 지식 (Background)",
+        "inferred": "심화/추론 (Inferred / Logic)"
+    })
+
+
 class RenderConfig(BaseModel):
     """최종 마크다운 리포트 생성 시 포맷팅 옵션을 설정한다."""
     model_config = ConfigDict(extra="forbid")
 
     include_sources: bool = False
     md_wrap_width: int = Field(..., ge=0)
+    groups: Optional[RenderGroupsConfig] = None
 
 
 class FinalSummaryStyleConfig(BaseModel):


### PR DESCRIPTION
## 요약
Fusion 모듈을 개선하여 ID 보존 기능 및 렌더러 기능을 강화합니다.

## 변경 사항

### src/fusion/config.py
- `load_judge_config()` 함수 추가 (Judge 설정 로딩)
- `load_pipeline_config()` 함수 추가 (Pipeline 설정 로딩)

### src/fusion/sync_engine.py
- 세그먼트 융합 시 원본 `stt_XXX`, `cap_XXX` ID 보존
- 세그먼트 출력에 `"source_stt_ids"`, `"source_cap_ids"` 필드 추가
- 글로벌 ID 추적으로 세그먼트 경계 감지 개선

### src/fusion/summarizer.py
- YAML 설정에서 프롬프트 로딩 리팩토링
- 버전별 프롬프트를 위한 `prompt_version` 지원 추가
- 오류 처리 및 JSON 복구 로직 개선

### src/fusion/renderer.py
- 그룹별 렌더링 추가 (direct/background/inferred 카테고리)
- 마크다운 출력 포맷팅 개선
- 커스터마이즈 가능한 헤더를 위한 `render.groups` 설정 지원
- 유지보수성 향상을 위한 렌더 로직 리팩토링

---

## Summary
Enhance Fusion module with ID preservation and renderer improvements.

## Changes

### src/fusion/config.py
- Add `load_judge_config()` function for Judge settings loading
- Add `load_pipeline_config()` function for Pipeline settings loading

### src/fusion/sync_engine.py
- Preserve original `stt_XXX` and `cap_XXX` IDs during segment fusion
- Add `"source_stt_ids"` and `"source_cap_ids"` to segment output
- Improve segment boundary detection with global ID tracking

### src/fusion/summarizer.py
- Refactor prompt loading from YAML config
- Add `prompt_version` support for versioned prompts
- Improve error handling and JSON repair logic

### src/fusion/renderer.py
- Add grouped rendering (direct/background/inferred categories)
- Improve markdown output formatting
- Add `render.groups` config support for customizable headers
- Refactor render logic for better maintainability