### PR TITLE
[Feature] STT/Capture 모듈에 고유 ID 생성 기능 추가 (stt_XXX, cap_XXX)

### DIFF
--- a/src/audio/clova_stt.py
+++ b/src/audio/clova_stt.py
@@ -14,6 +14,7 @@ ENV_PATH = Path(__file__).resolve().parents[2] / ".env"
 def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[Dict[str, Any]]:
     """Clova 응답에서 세그먼트 목록을 추출해 표준 형태로 정리한다."""
     segments_out: List[Dict[str, Any]] = []
+    segment_index = 0
     for segment in raw.get("segments", []):
         if not isinstance(segment, dict):
             continue
@@ -23,6 +24,7 @@ def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[
         text = text.strip()
         if not text:
             continue
+        segment_index += 1
         try:
             start_ms = int(round(float(segment.get("start"))))
         except (TypeError, ValueError):
@@ -35,6 +37,7 @@ def _extract_segments(raw: Dict[str, Any], *, include_confidence: bool) -> List[
             "start_ms": start_ms,
             "end_ms": end_ms,
             "text": text,
+            "id": f"stt_{segment_index:03d}",
         }
         if include_confidence:
             try:

--- a/src/audio/whisper_stt.py
+++ b/src/audio/whisper_stt.py
@@ -60,16 +60,19 @@ class WhisperSTTClient:
         )
 
         segments_out: List[Dict[str, Any]] = []
+        segment_index = 0
         for segment in result.get("segments", []):
             if not isinstance(segment, dict):
                 continue
             text = str(segment.get("text", "")).strip()
             if not text:
                 continue
+            segment_index += 1
             item: Dict[str, Any] = {
                 "start_ms": int(round(float(segment.get("start", 0.0)) * 1000)),
                 "end_ms": int(round(float(segment.get("end", 0.0)) * 1000)),
                 "text": text,
+                "id": f"stt_{segment_index:03d}",
             }
             if include_confidence:
                 confidence = _segment_confidence(segment)

--- a/src/capture/process_content.py
+++ b/src/capture/process_content.py
@@ -57,6 +57,10 @@ def process_single_video_capture(
     slides = extractor.process(video_name=video_name)
     elapsed = time.time() - start_time
 
+    # Assign IDs
+    for idx, slide in enumerate(slides, 1):
+        slide["id"] = f"cap_{idx:03d}"
+
     manifest_path = output_root / "manifest.json"
     with manifest_path.open("w", encoding="utf-8") as handle:
         json.dump(slides, handle, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## 요약
STT 및 Capture 모듈에 고유 ID 생성 기능을 추가합니다. 파이프라인 전반에서 각 세그먼트/슬라이드 추적이 가능해집니다.

## 변경 사항

### src/audio/clova_stt.py
- `segment_index` 카운터 추가
- 각 세그먼트에 `"id": "stt_XXX"` 필드 추가 (3자리 zero-padding)

### src/audio/whisper_stt.py
- `segment_index` 카운터 추가
- 각 세그먼트에 `"id": "stt_XXX"` 필드 추가 (3자리 zero-padding)

### src/capture/process_content.py
- ID 할당 루프 추가
- 각 슬라이드에 `"id": "cap_XXX"` 필드 추가 (3자리 zero-padding)

## 출력 예시

### STT 세그먼트
```json
{
  "start_ms": 0,
  "end_ms": 5000,
  "text": "안녕하세요",
  "id": "stt_001"
}
```

### Capture 슬라이드
```json
{
  "timestamp_ms": 1000,
  "file_name": "slide_001.jpg",
  "id": "cap_001"
}
```

## 관련 PR
- Re-View#80: [Feature] STT 모듈: stt_XXX 고유 ID 생성 기능 추가
- Re-View#81: [Feature] Capture 모듈: cap_XXX 고유 ID 생성 (파일명 변경 미적용)