### PR TITLE
feat: stream DB uploads per stage with overhead timing

### DIFF
--- a/src/db/adapters/video_adapter.py
+++ b/src/db/adapters/video_adapter.py
@@ -145,3 +145,21 @@ class VideoAdapterMixin:
         }
         result = self.client.table("pipeline_runs").insert(data).execute()
         return result.data[0] if result.data else {}
+
+    def update_pipeline_run(
+        self,
+        pipeline_run_id: str,
+        run_meta: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """기존 pipeline_runs 레코드의 메타데이터를 갱신합니다."""
+        data: Dict[str, Any] = {"run_meta": run_meta}
+        status = run_meta.get("status") if isinstance(run_meta, dict) else None
+        if status:
+            data["status"] = status
+        result = (
+            self.client.table("pipeline_runs")
+            .update(data)
+            .eq("id", pipeline_run_id)
+            .execute()
+        )
+        return result.data[0] if result.data else {}


### PR DESCRIPTION
## 변경 사항
- STT/캡처 병렬(ThreadPoolExecutor) 실행은 유지하면서, 먼저 끝난 스테이지 결과부터 DB에 업로드하도록 전처리 동기화 흐름을 추가했습니다.
- 전처리용 DB sync 헬퍼(prepare/sync/finalize)와 pipeline_run 업데이트로 동일 run_id 기반 단계별 업로드/상태 갱신을 지원합니다.(STT가 먼저 끝나서 DB에 올라가도, 나중에 캡처가 올라갈 때 같은 실행(run)으로 묶여 있어야 함)
- 벤치마크에 `overhead` 스테이지를 자동 계산해 TOTAL 대비 잔여 시간을 표시합니다.
- 전처리 DB 업로드 오류를 단계별로 상세 로그 출력하도록 보강했습니다.

## 변경 유형
- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Style

## 관련 이슈
Closes # 104

## 테스트
- [ ] 로컬에서 테스트 완료

## 체크리스트
- [ ] 코드 스타일 가이드라인 준수
- [ ] 기존 테스트 통과 확인
