### PR TITLE
feat: allow skipping local JSON and sync payloads to DB

### DIFF
--- a/config/pipeline/settings.yaml
+++ b/config/pipeline/settings.yaml
@@ -4,6 +4,8 @@ vlm_batch_size: 2              # VLM 요청 배치 크기
 vlm_concurrency: 3             # VLM 병렬 요청 수
 vlm_show_progress: true        # VLM 진행 로그
 batch_size: 4                  # 캡처 배치 크기(VLM/Sync/Summarize/Judge까지 처리됨)
+preprocess:
+  write_local_json: false     # 전처리 JSON(stt/manifest) 로컬 저장 여부
 
 video:
   preprocess_path: ""          # 전처리 입력 비디오 경로 (비워두면 CLI --video 사용)

--- a/src/audio/clova_stt.py
+++ b/src/audio/clova_stt.py
@@ -72,6 +72,7 @@ class ClovaSpeechClient:
         media_path: str | Path,
         output_path: str | Path | None = None,
         *,
+        write_output: bool = True,
         include_confidence: bool = True,
         include_raw_response: bool = False,
         word_alignment: bool = False,
@@ -86,11 +87,12 @@ class ClovaSpeechClient:
         if not media_path.exists():
             raise FileNotFoundError(f"Media file not found: {media_path}")
 
-        if output_path is None:
-            output_path = Path("src/data/output") / media_path.stem / "stt.json"
-        else:
-            output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if write_output:
+            if output_path is None:
+                output_path = Path("src/data/output") / media_path.stem / "stt.json"
+            else:
+                output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
 
         payload = {
             "language": language,
@@ -128,7 +130,7 @@ class ClovaSpeechClient:
         if include_raw_response:
             stt_data["raw_response"] = raw
 
-        output_path.write_text(json.dumps(stt_data, ensure_ascii=False, indent=2), encoding="utf-8")
+        if write_output and output_path is not None:
+            output_path.write_text(json.dumps(stt_data, ensure_ascii=False, indent=2), encoding="utf-8")
 
         return stt_data
-

--- a/src/audio/stt_router.py
+++ b/src/audio/stt_router.py
@@ -67,6 +67,8 @@ class STTRouter:
         media_path: str | Path,
         *,
         provider: str | None = None,
+        output_path: str | Path | None = None,
+        write_output: bool = True,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """지정된 제공자로 STT를 실행한다."""
@@ -78,12 +80,20 @@ class STTRouter:
         kwargs = _merge_defaults(provider_defaults, kwargs)
 
         if provider_name == "clova":
-            return ClovaSpeechClient().transcribe(media_path, **kwargs)
+            return ClovaSpeechClient().transcribe(
+                media_path,
+                output_path=output_path,
+                write_output=write_output,
+                **kwargs,
+            )
         if provider_name == "whisper":
             model_size = kwargs.pop("model_size", "base")
             device = kwargs.pop("device", None)
             return WhisperSTTClient(model_size=model_size, device=device).transcribe(
-                media_path, **kwargs
+                media_path,
+                output_path=output_path,
+                write_output=write_output,
+                **kwargs,
             )
 
         raise ValueError(f"Unsupported STT provider: {provider_name}")
@@ -94,10 +104,12 @@ class STTRouter:
         *,
         provider: str | None = None,
         audio_output_path: str | Path | None = None,
+        output_path: str | Path | None = None,
         mono_method: Optional[str] = None,
         sample_rate: Optional[int] = None,
         channels: Optional[int] = None,
         codec: Optional[str] = None,
+        write_output: bool = True,
         **stt_kwargs: Any,
     ) -> Dict[str, Any]:
         """오디오를 추출한 뒤 선택된 제공자로 STT를 실행한다."""
@@ -122,7 +134,13 @@ class STTRouter:
             mono_method=mono_method,
         )
         try:
-            return self.transcribe(audio_path, provider=provider, **stt_kwargs)
+            return self.transcribe(
+                audio_path,
+                provider=provider,
+                output_path=output_path,
+                write_output=write_output,
+                **stt_kwargs,
+            )
         finally:
             if not keep_audio:
                 Path(audio_path).unlink(missing_ok=True)

--- a/src/audio/whisper_stt.py
+++ b/src/audio/whisper_stt.py
@@ -41,6 +41,7 @@ class WhisperSTTClient:
         audio_path: str | Path,
         output_path: str | Path | None = None,
         *,
+        write_output: bool = True,
         include_confidence: bool = False,
         include_raw_response: bool = False,
         language: str = "ko",
@@ -87,12 +88,12 @@ class WhisperSTTClient:
         if include_raw_response:
             stt_data["raw_response"] = result
 
-        if output_path is None:
-            output_path = Path("src/data/output") / audio_path.stem / "stt.json"
-        else:
-            output_path = Path(output_path)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(json.dumps(stt_data, ensure_ascii=False, indent=2), encoding="utf-8")
+        if write_output:
+            if output_path is None:
+                output_path = Path("src/data/output") / audio_path.stem / "stt.json"
+            else:
+                output_path = Path(output_path)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps(stt_data, ensure_ascii=False, indent=2), encoding="utf-8")
 
         return stt_data
-

--- a/src/capture/process_content.py
+++ b/src/capture/process_content.py
@@ -18,6 +18,7 @@ def process_single_video_capture(
     scene_threshold: Optional[float] = None,
     dedupe_threshold: Optional[float] = None,
     min_interval: Optional[float] = None,
+    write_manifest: bool = True,
 ) -> list:
     """
     run_preprocess_pipeline.py에서 호출되는 캡쳐 인터페이스.
@@ -29,6 +30,7 @@ def process_single_video_capture(
     scene_threshold: 장면 전환 감지 임계값(None이면 설정값 사용).
     dedupe_threshold: 미사용 파라미터(호환 유지용).
     min_interval: 최소 캡처 간격(None이면 설정값 사용).
+    write_manifest: manifest.json 저장 여부.
 
     반환: 추출된 슬라이드 메타데이터 리스트.
     """
@@ -61,9 +63,10 @@ def process_single_video_capture(
     for idx, slide in enumerate(slides, 1):
         slide["id"] = f"cap_{idx:03d}"
 
-    manifest_path = output_root / "manifest.json"
-    with manifest_path.open("w", encoding="utf-8") as handle:
-        json.dump(slides, handle, ensure_ascii=False, indent=2)
+    if write_manifest:
+        manifest_path = output_root / "manifest.json"
+        with manifest_path.open("w", encoding="utf-8") as handle:
+            json.dump(slides, handle, ensure_ascii=False, indent=2)
 
     print(f"[Capture] Completed: {len(slides)} slides in {elapsed:.2f}s")
     return slides

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -130,16 +130,23 @@ def generate_fusion_config(
     )
 
 
-def run_stt(video_path: Path, output_stt_json: Path, *, backend: str) -> None:
-    """음성 인식을 실행해 stt.json을 생성한다."""
+def run_stt(
+    video_path: Path,
+    output_stt_json: Optional[Path],
+    *,
+    backend: str,
+    write_output: bool = True,
+) -> Dict[str, Any]:
+    """음성 인식을 실행해 stt 결과를 반환한다."""
     router = STTRouter(provider=backend)
-    # extract_audio가 코덱에 맞는 확장자를 자동 결정하므로 output_path를 None으로 전달
-    router.transcribe_media(
+    audio_output_path = output_stt_json.with_name(f"{video_path.stem}.wav") if output_stt_json else None
+    return router.transcribe_media(
         video_path,
         provider=backend,
         audio_output_path=None,  # 코덱 설정에 따라 자동 결정
         mono_method="auto",
-        output_path=output_stt_json,
+        output_path=output_stt_json if write_output else None,
+        write_output=write_output,
     )
 
 
@@ -152,6 +159,7 @@ def run_capture(
     min_interval: float,
     verbose: bool,
     video_name: str,
+    write_manifest: bool = True,
 ) -> List[Dict[str, Any]]:
     """슬라이드 캡처를 실행하고 메타데이터 목록을 반환한다."""
     metadata = process_single_video_capture(
@@ -160,6 +168,7 @@ def run_capture(
         scene_threshold=threshold,
         dedupe_threshold=dedupe_threshold,
         min_interval=min_interval,
+        write_manifest=write_manifest,
     )
     return metadata
 


### PR DESCRIPTION
## 변경 사항
- 전처리에서 `write_local_json` 설정/CLI를 추가하고 기본값을 false로 둬 로컬 JSON 생성을 선택적으로 비활성화
- STT/캡처 결과를 메모리 payload로 DB sync에 전달하고 파일 기반 업로드는 fallback으로 유지
- manifest 없이도 캡처 업로드/메타 저장이 가능하도록 payload 기반 업로드 경로 추가

## 변경 유형
- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 🔧 Refactor
- [ ] 📝 Documentation
- [ ] 🎨 Style

## 테스트
- [ ] 로컬에서 테스트 완료

## 체크리스트
- [ ] 코드 스타일 가이드라인 준수
- [ ] 기존 테스트 통과 확인
