### PR TITLE
feat: Capture 로직 마이그레이션 및 병렬 처리 개선

### DIFF
--- a/config/capture/settings.yaml
+++ b/config/capture/settings.yaml
@@ -1,11 +1,18 @@
 # 캡처 입력/출력 경로
-input_dir: data/input        # 입력 비디오 디렉토리
+input_dir: data/inputs        # 입력 비디오 디렉토리
 output_dir: data/outputs      # 출력 디렉토리
 
-# 슬라이드 전환 감지/필터링 설정
-sensitivity_diff: 3.0            # 픽셀 차이 민감도(낮을수록 민감)
-sensitivity_sim: 0.8             # ORB 유사도 임계값(높을수록 엄격)
-min_interval: 0.5                # 연속 캡처 최소 간격(초)
-sample_interval_sec: 0.5         # 유휴 상태 샘플링 간격(초)
-buffer_duration_sec: 2.5         # 전환 후 버퍼링 지속 시간(초)
-transition_timeout_sec: 2.5      # 전환 상태 최대 대기 시간(초)
+# 특징점 기반 추출 핵심 설정
+sample_interval_sec: 0.5         # 분석 프레임 샘플링 간격 (초)
+persistence_threshold: 6         # 특징점 유효 인정을 위한 최소 지속 샘플 수
+persistence_drop_ratio: 0.4      # 슬라이드 종료 판단을 위한 특징점 감소 비율
+min_orb_features: 50             # 새 슬라이드 인식을 위한 최소 특징점 수
+
+# 중복 제거 설정
+dedup_phash_threshold: 12        # pHash 해밍 거리 임계값
+dedup_orb_distance: 60           # ORB 매칭 거리 임계값
+dedup_sim_threshold: 0.5         # 중복 판정 유사도 임계값
+
+# 하위 호환성용 필드
+sensitivity_diff: 0.3            # 전이 감지 임계값
+min_interval: 0.5                # 최소 캡처 간격 (초)

--- a/config/vlm/settings.yaml
+++ b/config/vlm/settings.yaml
@@ -6,6 +6,7 @@ request_params:
   max_tokens: null          # 최대 생성 토큰 수 (null = 한도 내에서 가능한 만큼 생성)
   presence_penalty: 0.0     # 새로운 주제/단어를 얼마나 유도할지
   frequency_penalty: 0.1    # 동일 단어 반복 억제 정도
+  timeout: 60               # 요청 제한 시간 (초)
   stream: false             # 스트리밍 응답 여부 (false = 한 번에 결과 수신)
   stop:                     # 모델 출력 중단 토큰
     - "</s>"

--- a/src/audio/extract_audio.py
+++ b/src/audio/extract_audio.py
@@ -84,21 +84,24 @@ def _select_best_mono_method(media_path: Path, *, sample_rate: int, probe_second
     """여러 모노 방식 중 평균 볼륨이 가장 큰 방식을 선택한다."""
     candidates = ["downmix", "left", "right", "phase-fix"]
     volumes: dict[str, float] = {}
+    stats_list = []
     for candidate in candidates:
         volume = _measure_mean_volume(
             media_path, mono_method=candidate, sample_rate=sample_rate, probe_seconds=probe_seconds
         )
         if volume is None:
-            print(f"[STT]] mono-method candidate={candidate} mean_volume=NA")
+            stats_list.append(f"{candidate}=NA")
             continue
         volumes[candidate] = volume
-        print(f"[STT] mono-method candidate={candidate} mean_volume={volume} dB")
+        stats_list.append(f"{candidate}={volume}dB")
+
+    print(f"[Audio] mono-method candidates: {' | '.join(stats_list)}")
 
     if not volumes:
         return "downmix"
 
     best_method = max(volumes, key=volumes.get)
-    print(f"[STT] mono-method auto selected: {best_method} (mean_volume={volumes[best_method]} dB)")
+    print(f"[Audio] mono-method auto selected: {best_method} (max volume)")
     return best_method
 
 

--- a/src/capture/settings.py
+++ b/src/capture/settings.py
@@ -1,4 +1,17 @@
-"""캡처 단계 설정을 로드하는 유틸리티."""
+"""
+[Intent]
+캡처 단계에 필요한 각종 설정값(임계값, 샘플링 주기 등)을 
+YAML 파일로부터 로드하고 유효성을 검증하여 파이썬 객체로 제공하는 모듈입니다.
+
+[Usage]
+- run_preprocess_pipeline.py에서 캡처 설정을 초기화할 때 호출됩니다.
+- process_content.py에서 실제 캡처 엔진에 설정을 전달하기 위해 사용됩니다.
+
+[Usage Method]
+- get_capture_settings()를 호출하여 캐시된 설정 객체를 가져옵니다.
+- load_capture_settings()를 통해 특정 경로의 YAML 파일을 직접 로드할 수 있습니다.
+- 모든 경로는 프로젝트 루트를 기준으로 자동 해결(Resolve)됩니다.
+"""
 
 from __future__ import annotations
 
@@ -9,32 +22,48 @@ from typing import Any, Dict, Optional
 
 import yaml
 
+# 프로젝트 루트 경로 (src/capture/settings.py 기준 2단계 상위)
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-SETTINGS_PATH = PROJECT_ROOT / "config" / "capture" / "settings.yaml"
+# 기본 설정 파일 경로
+DEFAULT_SETTINGS_PATH = PROJECT_ROOT / "config" / "capture" / "settings.yaml"
 
 
 @dataclass(frozen=True)
 class CaptureSettings:
-    """캡처 단계에서 사용하는 설정 값 묶음."""
+    """
+    [Class Purpose]
+    캡처 엔진의 동작을 제어하는 파라미터들을 담는 불변(Immutable) 데이터 클래스입니다.
+    """
+    input_dir: Path              # 입력 비디오 디렉토리
+    output_dir: Path             # 결과 저장 디렉토리
+    
+    # --- 특징점 기반 추출 핵심 설정 ---
+    sample_interval_sec: float    # 분석 프레임 샘플링 간격 (초)
+    persistence_threshold: int    # 특징점 유효 인정을 위한 최소 지속 샘플 수
+    persistence_drop_ratio: float # 슬라이드 종료 판단을 위한 특징점 감소 비율
+    min_orb_features: int         # 새 슬라이드 인식을 위한 최소 특징점 수
 
-    input_dir: Path
-    output_dir: Path
-    sensitivity_diff: float
-    sensitivity_sim: float
-    min_interval: float
-    sample_interval_sec: float
-    buffer_duration_sec: float
-    transition_timeout_sec: float
+    # --- 중복 제거 설정 ---
+    dedup_phash_threshold: int    # pHash 해밍 거리 임계값 (기본: 12)
+    dedup_orb_distance: int       # ORB 매칭 거리 임계값 (기본: 60)
+    dedup_sim_threshold: float    # 중복 판정 유사도 임계값 (기본: 0.5)
+
+    # --- 하위 호환성용 필드 ---
+    sensitivity_diff: float       # 구버전 전이 감지 임계값
+    min_interval: float           # 최소 캡처 간격 (초)
 
 
 def _coerce_str(settings: Dict[str, Any], key: str, default: str) -> str:
+    """[Purpose] 설정 사전에서 값을 가져와 문자열로 강제 변환합니다."""
     value = settings.get(key, default)
     if not isinstance(value, str):
-        raise ValueError(f"capture 설정의 {key} 형식이 올바르지 않습니다(문자열이어야 함).")
+        # 숫자가 들어온 경우에도 문자열로 수용
+        return str(value)
     return value
 
 
 def _coerce_float(settings: Dict[str, Any], key: str, default: float) -> float:
+    """[Purpose] 설정 사전에서 값을 가져와 소수점(float)으로 강제 변환합니다."""
     value = settings.get(key, default)
     try:
         return float(value)
@@ -42,7 +71,17 @@ def _coerce_float(settings: Dict[str, Any], key: str, default: float) -> float:
         raise ValueError(f"capture 설정의 {key} 값이 올바르지 않습니다: {value}") from exc
 
 
+def _coerce_int(settings: Dict[str, Any], key: str, default: int) -> int:
+    """[Purpose] 설정 사전에서 값을 가져와 정수(int)로 강제 변환합니다."""
+    value = settings.get(key, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"capture 설정의 {key} 값이 올바르지 않습니다: {value}") from exc
+
+
 def _resolve_path(path_value: str) -> Path:
+    """[Purpose] 상대 경로 문자열을 프로젝트 루트 기준의 절대 경로로 변환합니다."""
     path = Path(path_value)
     if path.is_absolute():
         return path
@@ -50,30 +89,89 @@ def _resolve_path(path_value: str) -> Path:
 
 
 def load_capture_settings(*, settings_path: Optional[Path] = None) -> CaptureSettings:
-    """config/capture/settings.yaml을 읽어 CaptureSettings로 변환한다."""
-    path = settings_path or SETTINGS_PATH
+    """
+    [Usage File] run_preprocess_pipeline.py
+    [Purpose] 지정된 경로의 YAML 파일을 읽어 CaptureSettings 객체를 생성합니다.
+    [Connection] 로컬 파일 시스템(YAML)
+    
+    [Args]
+    - settings_path (Optional[Path]): 로드할 설정 파일 경로. 생략 시 기본 경로 사용.
+    
+    [Returns]
+    - CaptureSettings: 유효성이 검증된 설정 객체
+    """
+    path = settings_path or DEFAULT_SETTINGS_PATH
     if not path.exists():
         raise FileNotFoundError(f"capture 설정 파일을 찾을 수 없습니다: {path}")
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError("capture 설정 형식이 올바르지 않습니다(맵이어야 함).")
+    
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"YAML 파싱 중 에러가 발생했습니다: {exc}")
 
-    input_dir = _resolve_path(_coerce_str(payload, "input_dir", "data/input"))
+    if not isinstance(payload, dict):
+        raise ValueError("capture 설정 형식이 올바르지 않습니다(Map 구조여야 함).")
+
+    # 경로 해결
+    input_dir = _resolve_path(_coerce_str(payload, "input_dir", "data/inputs"))
     output_dir = _resolve_path(_coerce_str(payload, "output_dir", "data/outputs"))
+
+    # [Security] 경로 범위 검증 (data/inputs, data/outputs 이외 금지)
+    allowed_inputs = (PROJECT_ROOT / "data" / "inputs").resolve()
+    allowed_outputs = (PROJECT_ROOT / "data" / "outputs").resolve()
+
+    def _check_allowed(path_obj: Path, label: str):
+        p = path_obj.resolve()
+        is_valid = False
+        if p == allowed_inputs or p == allowed_outputs:
+            is_valid = True
+        else:
+            try:
+                p.relative_to(allowed_inputs)
+                is_valid = True
+            except ValueError:
+                try:
+                    p.relative_to(allowed_outputs)
+                    is_valid = True
+                except ValueError:
+                    pass
+        if not is_valid:
+            try:
+                rel_path = p.relative_to(PROJECT_ROOT)
+            except ValueError:
+                rel_path = p
+            error_msg = f"[Path Error] {label}이 허용된 범위를 벗어났습니다: {rel_path}\n(허용 범위: data/inputs 또는 data/outputs)"
+            print(error_msg)
+            raise RuntimeError(error_msg)
+
+    _check_allowed(input_dir, "Capture Input Dir")
+    _check_allowed(output_dir, "Capture Output Dir")
 
     return CaptureSettings(
         input_dir=input_dir,
         output_dir=output_dir,
-        sensitivity_diff=_coerce_float(payload, "sensitivity_diff", 3.0),
-        sensitivity_sim=_coerce_float(payload, "sensitivity_sim", 0.8),
-        min_interval=_coerce_float(payload, "min_interval", 0.5),
         sample_interval_sec=_coerce_float(payload, "sample_interval_sec", 0.5),
-        buffer_duration_sec=_coerce_float(payload, "buffer_duration_sec", 2.5),
-        transition_timeout_sec=_coerce_float(payload, "transition_timeout_sec", 2.5),
+        persistence_threshold=_coerce_int(payload, "persistence_threshold", 6),
+        persistence_drop_ratio=_coerce_float(payload, "persistence_drop_ratio", 0.4),
+        min_orb_features=_coerce_int(payload, "min_orb_features", 50),
+        
+        # Deduplication params
+        dedup_phash_threshold=_coerce_int(payload, "dedup_phash_threshold", 12),
+        dedup_orb_distance=_coerce_int(payload, "dedup_orb_distance", 60),
+        dedup_sim_threshold=_coerce_float(payload, "dedup_sim_threshold", 0.5),
+
+        sensitivity_diff=_coerce_float(payload, "sensitivity_diff", 0.3),
+        min_interval=_coerce_float(payload, "min_interval", 0.5),
     )
 
 
 @lru_cache(maxsize=1)
 def get_capture_settings() -> CaptureSettings:
-    """캡처 설정을 한 번만 로드해 캐시한다."""
+    """
+    [Usage File] process_content.py, run_preprocess_pipeline.py
+    [Purpose] 시스템 전체에서 사용될 캡처 설정을 싱글톤 형태로 제공합니다 (LRU 캐시 활용).
+    
+    [Returns]
+    - CaptureSettings: 캐시된 설정 객체 (최초 호출 시 로드)
+    """
     return load_capture_settings()

--- a/src/capture/tools/hybrid_extractor.py
+++ b/src/capture/tools/hybrid_extractor.py
@@ -1,681 +1,425 @@
 """
-강의 영상에서 슬라이드를 캡처하는 HybridSlideExtractor 구현.
+[Intent]
+비디오 프레임 내의 특징점(ORB) 지속성을 분석하여 슬라이드를 추출하고, 
+동일한 슬라이드가 반복될 경우 재저장하지 않고 시간 구간(Time Ranges)을 병합하는 엔진입니다.
+화면의 변화량(Pixel Difference)감지가 아닌, '특징점의 공간적 지속성(Persistence)'을 기반으로 
+동적 애니메이션과 정적 슬라이드를 정밀하게 구분합니다.
 
-중복 슬라이드 제거 최적화:
-- pHash로 O(1) 빠른 중복 검사
-- 이전 저장 슬라이드들과 ORB 상세 비교
-- time_ranges 병합으로 VLM 호출 최소화
+[Usage]
+- src/capture/process_content.py 에서 캡처 작업을 수행할 때 메인 유틸리티로 활용됩니다.
+- 대규모 비디오 강좌나 발표 자료 등 화자가 영상을 포함하면서도 정적인 슬라이드가 교체되는 상황에 최적화되어 있습니다.
+
+[Usage Method]
+- HybridSlideExtractor를 생성할 때 비디오 경로와 설정 파라미터를 전달합니다.
+- .process() 메서드를 호출하여 프레임을 순차 분석하고, 중복이 제거되고 구간이 병합된 슬라이드 결과를 반환받습니다.
+- 반환된 List[dict]는 manifest.json 생성에 직접 사용될 수 있는 구조를 가집니다.
 """
+
+import os
+from pathlib import Path
+from typing import List, Dict, Any, Optional, Tuple
 
 import cv2
 import numpy as np
-import os
-from typing import List, Dict, Any, Optional, Tuple
 
-
-def calculate_phash(image: np.ndarray, hash_size: int = 8) -> str:
-    """
-    이미지의 Perceptual Hash(pHash)를 계산한다.
-
-    DCT 기반 해시로 리사이즈/압축에 강건하다.
-    
-    Args:
-        image: BGR 이미지 (numpy array)
-        hash_size: 해시 크기 (기본 8 = 64비트 해시)
-    
-    Returns:
-        16진수 해시 문자열
-    """
-    # 그레이스케일 변환 및 32x32로 리사이즈
-    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
-    resized = cv2.resize(gray, (hash_size * 4, hash_size * 4), interpolation=cv2.INTER_AREA)
-    
-    # DCT 계산
-    dct = cv2.dct(np.float32(resized))
-    dct_low = dct[:hash_size, :hash_size]
-    
-    # 중간값 기준 이진화
-    median = np.median(dct_low)
-    bits = (dct_low > median).flatten()
-    
-    # 64비트를 16진수 문자열로 변환
-    hash_int = sum(1 << i for i, bit in enumerate(bits) if bit)
-    return format(hash_int, '016x')
-
-
-def hamming_distance(hash1: str, hash2: str) -> int:
-    """두 pHash 간의 해밍 거리를 계산한다."""
-    if len(hash1) != len(hash2):
-        return 64  # 최대 거리 반환
-    val1 = int(hash1, 16)
-    val2 = int(hash2, 16)
-    xor = val1 ^ val2
-    return bin(xor).count('1')
-
-
-def calculate_info_score(image: np.ndarray, orb_features: int) -> float:
-    """
-    이미지의 정보량 점수를 계산한다.
-    
-    ORB 특징점 수 (60%) + 엣지 밀도 (40%) 가중 평균.
-    
-    Args:
-        image: BGR 이미지
-        orb_features: ORB 특징점 수
-    
-    Returns:
-        0~1 사이의 정보량 점수
-    """
-    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
-    
-    # 엣지 밀도 계산 (Canny)
-    edges = cv2.Canny(gray, 50, 150)
-    edge_density = np.sum(edges > 0) / edges.size
-    
-    # ORB 특징점 정규화 (500개 기준)
-    orb_normalized = min(orb_features / 500.0, 1.0)
-    
-    # 가중 평균
-    return 0.6 * orb_normalized + 0.4 * edge_density
-
-
-def _format_time(ms: int) -> str:
-    """밀리초를 MM:SS 형식으로 변환한다."""
-    seconds = ms // 1000
-    minutes = seconds // 60
-    sec = seconds % 60
-    return f"{minutes:02d}:{sec:02d}"
-
+from src.pipeline.logger import pipeline_logger
 
 
 class HybridSlideExtractor:
     """
-    픽셀 차이와 ORB 유사도를 결합해 슬라이드 전환을 감지하는 캡처 엔진.
+    [Class Purpose]
+    특징점(ORB) 기반의 Streak Detection 알고리즘과 1-Stage Online Deduplication을 결합하여
+    최적의 슬라이드 캡처 및 그룹화를 수행합니다.
 
-    전환 이후 일정 시간 버퍼를 모아 노이즈가 적은 프레임을 선택하고,
-    지연 저장 방식으로 end_ms가 확정된 뒤 한 번만 저장한다.
+    [Connection]
+    - OpenCV (cv2): 영상 프레임 디코딩, 특징점 추출(ORB), 이미지 저장, 이미지 해싱
+    - NumPy: 특징점 격자 계산 및 지속성 맵 연산
     """
-    
+
     def __init__(
-        self,
-        video_path,
-        output_dir,
-        sensitivity_diff=3.0,
-        sensitivity_sim=0.6,  # Relaxed from 0.8 for better slide merging
-        min_interval=0.5,
-        sample_interval_sec=0.5,  # Accuracy priority
-        buffer_duration_sec=2.5,
-        transition_timeout_sec=2.5,
-        dedup_enabled=True,
-        phash_threshold=15,  # pHash Hamming distance threshold
+        self, 
+        video_path: str, 
+        output_dir: str, 
+        persistence_drop_ratio: float = 0.4, 
+        sample_interval_sec: float = 0.5,
+        persistence_threshold: int = 6,
+        min_orb_features: int = 50,
+        dedup_phash_threshold: int = 12,
+        dedup_orb_distance: int = 60,
+        dedup_sim_threshold: float = 0.5
     ):
         """
-        캡처 엔진을 초기화한다.
-
-        video_path: 입력 비디오 파일 경로.
-        output_dir: 캡처 이미지를 저장할 디렉터리.
-        sensitivity_diff: 픽셀 차이 민감도(낮을수록 민감).
-        sensitivity_sim: ORB 유사도 임계값(높을수록 엄격).
-        min_interval: 연속 캡처 최소 간격(초).
-        sample_interval_sec: 유휴 상태에서 프레임을 샘플링하는 간격(초).
-        buffer_duration_sec: 전환 이후 버퍼링 지속 시간(초).
-        transition_timeout_sec: 전환 상태 최대 대기 시간(초).
-        dedup_enabled: 중복 제거 활성화 여부 (True: 중복 제거, False: 모든 슬라이드 저장).
+        [Usage File] src/capture/process_content.py
+        [Purpose] 슬라이드 추출기를 초기화하고 내부 상태 및 중복 제거를 위한 히스토리 저장소를 설정합니다.
+        
+        [Args]
+        - video_path (str): 입력 비디오 파일 경로
+        - output_dir (str): 슬라이드 이미지를 저장할 디렉토리
+        - persistence_drop_ratio (float): 현재 슬라이드가 종료되었다고 판단할 특징점 감소 비율 (0.4 = 40% 감소 시 종료)
+        - sample_interval_sec (float): 프레임 분석 간격 (기본 0.5초)
+        - persistence_threshold (int): 특징점이 유효한 요소로 인정받기 위한 최소 지속 횟수
+        - min_orb_features (int): 유의미한 슬라이드로 판단하기 위한 최소 특징점 개수
         """
-        if sample_interval_sec <= 0:
-            raise ValueError("sample_interval_sec must be > 0")
-        if buffer_duration_sec <= 0:
-            raise ValueError("buffer_duration_sec must be > 0")
-        if transition_timeout_sec <= 0:
-            raise ValueError("transition_timeout_sec must be > 0")
         self.video_path = video_path
         self.output_dir = output_dir
-        self.sensitivity_diff = sensitivity_diff
-        self.sensitivity_sim = sensitivity_sim
-        self.min_interval = min_interval
+        self.persistence_drop_ratio = persistence_drop_ratio
         self.sample_interval_sec = sample_interval_sec
-        self.buffer_duration_sec = buffer_duration_sec
-        self.buffer_duration_sec = buffer_duration_sec
-        self.transition_timeout_sec = transition_timeout_sec
-        self.dedup_enabled = dedup_enabled
-        self.phash_threshold = phash_threshold
+        self.persistence_threshold = persistence_threshold
+        self.min_orb_features = min_orb_features
+        self.dedup_phash_threshold = dedup_phash_threshold
+        self.dedup_orb_distance = dedup_orb_distance
+        self.dedup_sim_threshold = dedup_sim_threshold
         
-        # ORB 특징점 검출기 (최대 500개 특징점)
-        self.orb = cv2.ORB_create(nfeatures=500)
+        # 특징점 추출 엔진 설정 (ORB: 빠른 속도와 적절한 성능 제공)
+        self.orb = cv2.ORB_create(nfeatures=1500)
         
-        # Brute-Force 매처 (Hamming 거리 사용, crossCheck로 양방향 매칭)
-        self.bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+        # 내부 상태 변수
+        self.persistence_streak_map = None  # 특징점별 지속 횟수를 기록하는 히트맵
+        self.pending_slide = None           # 현재 추적 중인 잠재적 슬라이드(최대 정보량 프레임)
+        self.pending_features = 0           # 현재 슬라이드의 기준 특징점 수
+        self.current_slide_start_time = 0.0 # 현재 슬라이드의 시작 시간
         
-        # 출력 디렉토리 생성
-        os.makedirs(self.output_dir, exist_ok=True)
+        # 중복 제거 및 이력 관리
+        self.slide_count = 0                # 유니크 슬라이드 ID 발급용 카운터
+        self.saved_slides_history: List[Dict[str, Any]] = [] # 저장된 슬라이드들의 메타데이터 및 특징점 리스트
         
-        # 상태 변수 초기화
-        self.last_saved_frame = None
-        self.last_saved_kp = None
-        self.last_saved_des = None
-        
-        # Delayed Save를 위한 버퍼
-        self.pending_slide = None  # {"frame": ..., "start_ms": ...}
-        
-        # === 중복 제거 최적화 ===
-        # pHash 인덱스: {phash: slide_idx} - O(1) 중복 검사용
-        self.phash_index: Dict[str, int] = {}
-        
-        # 저장된 슬라이드 히스토리: 시간 범위 병합 및 대표 이미지 교체에 사용
-        # [{idx, frame, phash, info_score, time_ranges: [{start_ms, end_ms}], kp, des}, ...]
-        self.saved_slides_history: List[Dict[str, Any]] = []
-        
-        # 최근 N장에 대해 ORB 상세 비교 (pHash miss 대비)
-        self.orb_compare_limit = 5
-        
+        # pHash lookup table (Key: pHash string, Value: List of history indices)
+        # 여러 슬라이드가 비슷한 해시를 가질 수 있으므로 리스트로 관리
+        self.phash_index: Dict[str, List[int]] = {}
 
-    def process(self, video_name="video"):
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
+    def _compute_phash(self, image: np.ndarray) -> str:
         """
-        비디오를 순회하며 슬라이드를 추출한다.
+        [Usage File] Internal Use
+        [Purpose] 이미지의 Perceptual Hash(pHash)를 계산하여 이미지 유사도 비교의 1차 필터로 사용합니다.
+        
+        [Args]
+        - image (np.ndarray): BGR 이미지 배열
 
-        전환 감지 후 버퍼링한 프레임 중 최적 프레임을 선택하고,
-        다음 슬라이드가 감지될 때까지 저장을 지연한다.
-
-        video_name: 출력 파일명 접두사.
-        반환: [{"file_name": str, "start_ms": int, "end_ms": int}, ...]
+        [Returns]
+        - str: 16진수 형태의 64비트 해시 문자열
         """
-        cap = cv2.VideoCapture(self.video_path)
-        fps = cap.get(cv2.CAP_PROP_FPS)
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-        duration_ms = int((total_frames / fps) * 1000) if fps > 0 else 0
+        # 1. Grayscale 변환 및 32x32 리사이즈
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        resized = cv2.resize(gray, (32, 32))
         
-        # 상태 변수 초기화
-        prev_gray = None
-        prev_des = None
-        last_capture_time = -self.min_interval
-        self.last_saved_frame = None
-        self.pending_slide = None
+        # 2. DCT (Discrete Cosine Transform) 수행, float32 변환 필요
+        dct = cv2.dct(np.float32(resized))
         
-        is_in_transition = False
-        transition_start_time = 0.0
+        # 3. 저주파 영역(8x8) 추출 (가장 왼쪽 위 DC 성분 제외)
+        dct_low_freq = dct[0:8, 0:8]
         
-        frame_idx = 0
+        # 4. 평균값 계산 (DC 성분 제외하고 평균 내는 것이 정석이나, 간단하게 전체 평균 사용하기도 함)
+        avg = dct_low_freq.mean()
         
-        # Reset history for each process call
-        self.phash_index.clear()
-        self.saved_slides_history.clear()
+        # 5. 평균보다 크면 1, 작으면 0으로 비트 생성
+        diff = dct_low_freq > avg
         
-        slide_idx = 0  # 슬라이드 인덱스 (1-based)
-        
-        # 체크 간격 (유휴 상태 샘플링)
-        check_step = int(fps * self.sample_interval_sec)
-        if check_step < 1:
-            check_step = 1
-            
-        current_pending_capture = None
-        
-        while cap.isOpened():
-            # 1. 프레임 읽기
-            ret, frame = cap.read()
-            if not ret:
-                break
+        # 6. 비트를 16진수 문자열로 변환
+        # flatten 후 비트 합치기
+        bits = diff.flatten()
+        decimal_val = 0
+        for i, bit in enumerate(bits):
+            if bit:
+                decimal_val += 2 ** i
                 
-            frame_idx += 1
-            current_time = frame_idx / fps
-            
-            # 2. 스킵 로직 (IDLE 모드에서 프레임 건너뛰기)
-            if current_pending_capture is None and not is_in_transition:
-                if frame_idx % check_step != 0 and frame_idx != 1:
-                    continue
-            
-            # 3. 프레임 시그니처 계산
-            try:
-                small = cv2.resize(frame, (640, 360))
-            except cv2.error:
-                break
-            curr_gray = cv2.cvtColor(small, cv2.COLOR_BGR2GRAY)
-            curr_kp, curr_des = self.orb.detectAndCompute(curr_gray, None)
-            
-            should_finalize_buffer = False
-            
-            if prev_gray is not None:
-                # 4. 메트릭 계산
-                diff = cv2.absdiff(prev_gray, curr_gray)
-                _, thresh = cv2.threshold(diff, 30, 255, cv2.THRESH_BINARY)
-                kernel = np.ones((5, 5), np.uint8)
-                clean_diff = cv2.morphologyEx(thresh, cv2.MORPH_OPEN, kernel)
-                diff_val = np.mean(clean_diff)
-                
-                sim_val = 1.0
-                if prev_des is not None and curr_des is not None and len(prev_des) > 0 and len(curr_des) > 0:
-                    matches = self.bf.match(prev_des, curr_des)
-                    if len(matches) > 0:
-                        good_matches = [m for m in matches if m.distance < 50]
-                        sim_val = len(good_matches) / max(len(prev_des), len(curr_des))
-                
-                is_significant_change = (diff_val > self.sensitivity_diff or sim_val < self.sensitivity_sim)
-                
-                if not is_in_transition:
-                    # [인터럽트 로직] 버퍼링 중 새 전환 감지
-                    if current_pending_capture is not None and is_significant_change:
-                        should_finalize_buffer = True
-                        
-                    if is_significant_change and (current_time - last_capture_time) >= self.min_interval:
-                        is_in_transition = True
-                        transition_start_time = current_time
+        return hex(decimal_val)[2:]
 
-                else:
-                    # 안정성 확인
-                    is_stable = (diff_val < (self.sensitivity_diff / 4.0))
-                    time_in_transition = current_time - transition_start_time
-                    
-                    if is_stable or time_in_transition > self.transition_timeout_sec:
-                        is_in_transition = False
-                        if current_pending_capture is None:
-                            current_pending_capture = {
-                                'trigger_time': current_time,
-                                'buffer': [frame.copy()],
-                                'buffer_start': current_time
-                            }
-
-            
-            # 5. 스마트 버퍼링 로직
-            if current_pending_capture is not None:
-                if not should_finalize_buffer:
-                    current_pending_capture['buffer'].append(frame.copy())
-                    
-                buffer_duration = current_time - current_pending_capture['buffer_start']
-                if buffer_duration >= self.buffer_duration_sec or should_finalize_buffer:
-                    # 버퍼에서 최적 프레임 선택 및 중복 검사
-                    best_frame, should_save = self._select_best_frame_and_check_duplicate(
-                        current_pending_capture, curr_kp, curr_des
-                    )
-                    
-                    if should_save:
-                        new_start_ms = int(current_pending_capture['trigger_time'] * 1000)
-                        
-                        # 핵심: Delayed Save로 이전 pending_slide를 저장
-                        if self.pending_slide is not None:
-                            end_ms = new_start_ms
-                            self._handle_finished_slide(video_name, self.pending_slide, end_ms)
-                        
-                        # 현재 슬라이드를 pending으로 저장
-                        self.pending_slide = {
-                            'frame': best_frame,
-                            'start_ms': new_start_ms
-                        }
-                        self.last_saved_frame = best_frame
-                        
-                    last_capture_time = current_pending_capture['trigger_time']
-                    current_pending_capture = None
-            
-            # 다음 프레임 비교를 위해 업데이트
-            prev_gray = curr_gray
-            prev_des = curr_des
-            
-            # 첫 프레임 특수 처리
-            if frame_idx == 1:
-                current_pending_capture = {
-                    'trigger_time': current_time,
-                    'buffer': [frame.copy()],
-                    'buffer_start': current_time
-                }
-        
-        # 마지막 버퍼 처리
-        if current_pending_capture:
-            best_frame, should_save = self._select_best_frame_and_check_duplicate(
-                current_pending_capture, None, None
-            )
-            if should_save:
-                new_start_ms = int(current_pending_capture['trigger_time'] * 1000)
-                
-                if self.pending_slide is not None:
-                    self._handle_finished_slide(video_name, self.pending_slide, new_start_ms)
-                
-                self.pending_slide = {
-                    'frame': best_frame,
-                    'start_ms': new_start_ms
-                }
-        
-        # 마지막 pending_slide 저장 (end_ms = duration)
-        if self.pending_slide is not None:
-            self._handle_finished_slide(video_name, self.pending_slide, duration_ms)
-        
-        cap.release()
-
-        # === Option A: 첫 슬라이드 재비교 (history 비어있을 때 저장된 경우 대응) ===
-        self._merge_first_slide_if_duplicate()
-
-        # === 최종 결과 재구성: saved_slides_history에서 time_ranges 포함 출력 생성 ===
-        final_slides = []
-        for slide in self.saved_slides_history:
-            # Merge time ranges before final output (threshold: 200ms)
-            merged_ranges = self._merge_time_ranges(slide["time_ranges"], gap_threshold=200)
-            
-            final_slides.append({
-                "file_name": slide['file_name'],
-                "time_ranges": merged_ranges,
-            })
-        
-        print(f"  [Dedup] Final: {len(final_slides)} unique slides (history: {len(self.saved_slides_history)})")
-            
-        return final_slides
-
-    def _select_best_frame_and_check_duplicate(self, pending, curr_kp, curr_des):
+    def _hamming_distance(self, hash1: str, hash2: str) -> int:
         """
-        버퍼에서 최적 프레임을 고른다.
-        기존의 로컬 중복 검사는 제거됨 (Global Deduplication으로 대체).
+        [Usage File] Internal Use
+        [Purpose] 두 해시 문자열 간의 해밍 거리(다른 비트 수)를 계산합니다.
         """
-        if not pending['buffer']:
-            return None, False
-            
-        stack = np.array(pending['buffer'])
-        median_frame = np.median(stack, axis=0).astype(np.uint8)
-        median_gray = cv2.cvtColor(cv2.resize(median_frame, (640, 360)), cv2.COLOR_BGR2GRAY)
-        
-        best_frame = pending['buffer'][0]
-        best_diff = float('inf')
-        
-        for frame in pending['buffer']:
-            frame_gray = cv2.cvtColor(cv2.resize(frame, (640, 360)), cv2.COLOR_BGR2GRAY)
-            diff = np.mean(cv2.absdiff(median_gray, frame_gray))
-            if diff < best_diff:
-                best_diff = diff
-                best_frame = frame
-        
-        # 리팩토링: 로컬 중복 검사는 제거하고 무조건 True 반환
-        # 실제 중복 검사는 _handle_finished_slide에서 전역적으로 수행
-        should_save = True
-        
-        self.last_saved_frame = best_frame
-        
-        return best_frame, should_save
+        # 정수로 변환 후 XOR 연산
+        try:
+            val1 = int(hash1, 16)
+            val2 = int(hash2, 16)
+            xor_val = val1 ^ val2
+            return bin(xor_val).count('1')
+        except ValueError:
+            return 64 # 에러 시 최대 거리 반환
 
-
-    def _handle_finished_slide(self, video_name, slide_data, end_ms):
+    def _merge_time_ranges(self, ranges: List[Dict[str, int]], gap_threshold_ms: int = 200) -> List[Dict[str, int]]:
         """
-        슬라이드 처리가 끝났을 때 저장 및 중복 검사를 수행한다.
-        실제 저장 로직을 여기서 통합 처리함.
-        """
-        idx = len(self.saved_slides_history) + 1
+        [Usage File] Internal Use
+        [Purpose] 파편화된 시간 구간들을 병합하여 깔끔한 타임라인을 생성합니다.
         
-        # 파일명 형식: {video_name}_{idx:03d}.jpg
-        start_ms = slide_data['start_ms']
-        frame = slide_data['frame']
-        
-        # pHash 계산
-        phash = calculate_phash(frame)
-        
-        # ORB 특징점
-        gray = cv2.cvtColor(cv2.resize(frame, (640, 360)), cv2.COLOR_BGR2GRAY)
-        kp, des = self.orb.detectAndCompute(gray, None)
-        orb_count = len(kp) if kp else 0
-        
-        # 정보량 점수 계산
-        info_score = calculate_info_score(frame, orb_count)
-        
-        # 중복 검사: 기존 저장 슬라이드와 비교
-        duplicate_idx = self._find_duplicate_slide(frame, phash, kp, des)
-        
-        if duplicate_idx is not None:
-            # 중복 발견: 시간 범위만 추가
-            dup_slide = self.saved_slides_history[duplicate_idx]
-            dup_slide['time_ranges'].append({'start_ms': start_ms, 'end_ms': end_ms})
-            
-            # 정보량이 더 높으면 대표 이미지 교체
-            if info_score > dup_slide['info_score']:
-                new_filename = f"{video_name}_{dup_slide['idx']:03d}.jpg"
-                new_path = os.path.join(self.output_dir, new_filename)
-                
-                # 기존 파일과 이름이 다르면 삭제 (이름이 같은 경우 덮어쓰기됨)
-                if dup_slide['file_name'] != new_filename:
-                    old_path = os.path.join(self.output_dir, dup_slide['file_name'])
-                    if os.path.exists(old_path):
-                        try:
-                            os.remove(old_path)
-                        except OSError:
-                            pass
+        [Args]
+        - ranges: [{'start_ms': 100, 'end_ms': 2000}, ...] 형태의 리스트
+        - gap_threshold_ms: 이 시간(ms) 이하의 공백은 하나의 구간으로 병합
 
-                cv2.imwrite(new_path, frame)
-                
-                dup_slide['frame'] = frame
-                dup_slide['phash'] = phash
-                dup_slide['info_score'] = info_score
-                dup_slide['kp'] = kp
-                dup_slide['des'] = des
-                dup_slide['file_name'] = new_filename
-                
-                # pHash 인덱스 업데이트
-                self.phash_index[phash] = duplicate_idx
-                
-                # Logging with (replaced) suffix
-                fname = dup_slide['file_name'].replace(".jpg", "")
-                t_start = _format_time(start_ms)
-                t_end = _format_time(end_ms)
-                print(f"[Dedup] {fname} + {t_start}~{t_end} ({start_ms}~{end_ms}ms) (replaced)")
-            else:
-                # Logging without (replaced)
-                fname = dup_slide['file_name'].replace(".jpg", "")
-                t_start = _format_time(start_ms)
-                t_end = _format_time(end_ms)
-                print(f"[Dedup] {fname} + {t_start}~{t_end} ({start_ms}~{end_ms}ms)")
-            
-            return  # 새로 저장하지 않음
-        
-        # 새 슬라이드 저장
-        filename = f"{video_name}_{idx:03d}.jpg"
-        save_path = os.path.join(self.output_dir, filename)
-        cv2.imwrite(save_path, frame)
-        
-        # 히스토리에 추가
-        new_slide = {
-            'idx': idx,
-            'frame': frame,
-            'phash': phash,
-            'info_score': info_score,
-            'time_ranges': [{'start_ms': start_ms, 'end_ms': end_ms}],
-            'kp': kp,
-            'des': des,
-            'file_name': filename
-        }
-        self.saved_slides_history.append(new_slide)
-        self.phash_index[phash] = len(self.saved_slides_history) - 1
-        
-        # last_saved 업데이트
-        self.last_saved_frame = frame
-        self.last_saved_kp = kp
-        self.last_saved_des = des
-
-
-    def _find_duplicate_slide(
-        self,
-        frame: np.ndarray,
-        phash: str,
-        kp: Any,
-        des: Any
-    ) -> Optional[int]:
-        """
-        저장된 슬라이드 중 중복을 찾는다.
-        
-        1단계: pHash 해밍 거리로 빠른 후보 탐색 (O(n), 실제로는 매우 빠름)
-        2단계: 후보에 대해 ORB 상세 비교
-        
-        Returns:
-            중복 슬라이드의 인덱스 (없으면 None)
-        """
-        if not self.dedup_enabled:
-            return None
-
-        if not self.saved_slides_history:
-            return None
-        
-        # 1단계: pHash로 후보 탐색
-        candidates = []
-        for existing_phash, slide_idx in self.phash_index.items():
-            dist = hamming_distance(phash, existing_phash)
-            if dist <= self.phash_threshold:
-                candidates.append((slide_idx, dist))
-        
-        # 해밍 거리순 정렬
-        candidates.sort(key=lambda x: x[1])
-        
-        # 2단계: 후보 + 최근 N장에 대해 ORB 상세 비교
-        compare_indices = set([c[0] for c in candidates])
-        
-        # 최근 N장 추가 (pHash miss 대비)
-        recent_start = max(0, len(self.saved_slides_history) - self.orb_compare_limit)
-        for i in range(recent_start, len(self.saved_slides_history)):
-            compare_indices.add(i)
-        
-        if des is None or len(des) == 0:
-            # ORB 비교 불가 → pHash만으로 판단
-            if candidates and candidates[0][1] <= 5:  # 매우 유사
-                return candidates[0][0]
-            return None
-        
-        gray_new = cv2.cvtColor(cv2.resize(frame, (640, 360)), cv2.COLOR_BGR2GRAY)
-        
-        for slide_idx in compare_indices:
-            saved = self.saved_slides_history[slide_idx]
-            saved_des = saved.get('des')
-            saved_kp = saved.get('kp')
-            
-            if saved_des is None or len(saved_des) == 0:
-                continue
-            
-            # ORB 매칭
-            matches = self.bf.match(saved_des, des)
-            if not matches:
-                continue
-            
-            good_matches = [m for m in matches if m.distance < 50]
-            sim_score = len(good_matches) / max(len(saved_des), len(des))
-            
-            # 픽셀 차이
-            saved_gray = cv2.cvtColor(cv2.resize(saved['frame'], (640, 360)), cv2.COLOR_BGR2GRAY)
-            diff = cv2.absdiff(saved_gray, gray_new)
-            diff_score = np.mean(diff)
-            
-            # 중복 판정 기준
-            if sim_score >= 0.5 and (diff_score < self.sensitivity_diff or sim_score > self.sensitivity_sim):
-                return slide_idx
-            
-            # RANSAC 추가 검사
-            if len(good_matches) > 10 and saved_kp is not None and kp is not None:
-                src_pts = np.float32([saved_kp[m.queryIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-                dst_pts = np.float32([kp[m.trainIdx].pt for m in good_matches]).reshape(-1, 1, 2)
-                
-                if len(src_pts) > 4:
-                    M, mask = cv2.findHomography(src_pts, dst_pts, cv2.RANSAC, 5.0)
-                    if mask is not None:
-                        inlier_ratio = np.sum(mask) / len(saved_des) if len(saved_des) > 0 else 0
-                        if inlier_ratio > 0.15 and diff_score < 20.0 and sim_score >= 0.5:
-                            return slide_idx
-        
-        return None
-
-    def _merge_first_slide_if_duplicate(self) -> None:
-        """
-        첫 번째 슬라이드를 나머지 슬라이드들과 비교하여 중복 시 병합한다.
-        
-        첫 슬라이드는 history가 비어있을 때 저장되어 비교 대상이 없었으므로,
-        모든 저장 완료 후 재비교하여 중복 제거를 수행한다.
-        """
-        if not self.dedup_enabled:
-            return
-
-        if len(self.saved_slides_history) < 2:
-            return
-        
-        first = self.saved_slides_history[0]
-        first_phash = first['phash']
-        first_des = first.get('des')
-        first_kp = first.get('kp')
-        first_frame = first['frame']
-        
-        # 나머지 슬라이드들과 비교
-        for i in range(1, len(self.saved_slides_history)):
-            other = self.saved_slides_history[i]
-            
-            # pHash 비교
-            dist = hamming_distance(first_phash, other['phash'])
-            if dist > self.phash_threshold:
-                continue
-            
-            # ORB 비교
-            other_des = other.get('des')
-            if first_des is None or other_des is None:
-                continue
-            if len(first_des) == 0 or len(other_des) == 0:
-                continue
-            
-            matches = self.bf.match(first_des, other_des)
-            if not matches:
-                continue
-            
-            good_matches = [m for m in matches if m.distance < 50]
-            sim_score = len(good_matches) / max(len(first_des), len(other_des))
-            
-            # 픽셀 차이
-            first_gray = cv2.cvtColor(cv2.resize(first_frame, (640, 360)), cv2.COLOR_BGR2GRAY)
-            other_gray = cv2.cvtColor(cv2.resize(other['frame'], (640, 360)), cv2.COLOR_BGR2GRAY)
-            diff = cv2.absdiff(first_gray, other_gray)
-            diff_score = np.mean(diff)
-            
-            # 중복 판정
-            is_duplicate = False
-            if sim_score >= 0.5 and (diff_score < self.sensitivity_diff or sim_score > self.sensitivity_sim):
-                is_duplicate = True
-            
-            if is_duplicate:
-                # 첫 슬라이드의 time_ranges를 대상 슬라이드에 병합
-                for tr in first['time_ranges']:
-                    other['time_ranges'].insert(0, tr)  # 시간순으로 앞에 삽입
-                
-                # 정보량이 더 높으면 대표 이미지 교체
-                if first['info_score'] > other['info_score']:
-                    other['frame'] = first_frame
-                    other['phash'] = first_phash
-                    other['info_score'] = first['info_score']
-                    other['kp'] = first_kp
-                    other['des'] = first_des
-                    # 파일은 이미 저장되어 있으므로 교체 로직 필요 시 추가
-                
-                # 첫 슬라이드 제거
-                del self.saved_slides_history[0]
-                
-                # pHash 인덱스 재정렬
-                self.phash_index.clear()
-                for idx, slide in enumerate(self.saved_slides_history):
-                    self.phash_index[slide['phash']] = idx
-                
-                # 첫 슬라이드 파일 삭제
-                first_path = os.path.join(self.output_dir, first['file_name'])
-                if os.path.exists(first_path):
-                    os.remove(first_path)
-                
-                print(f"  [Dedup] First slide merged to #{other['idx']} (post-process)")
-                return
-
-    def _merge_time_ranges(self, ranges, gap_threshold=200):
-        """
-        Merge fragmented time ranges if the gap between them is small.
-        default gap_threshold = 200ms
+        [Returns]
+        - 병합된 시간 구간 리스트
         """
         if not ranges:
             return []
         
-        # Sort by start time
+        # 시작 시간 기준 정렬
         sorted_ranges = sorted(ranges, key=lambda x: x["start_ms"])
-        
         merged = []
         current = sorted_ranges[0].copy()
         
         for i in range(1, len(sorted_ranges)):
             next_range = sorted_ranges[i]
-            # Check gap (next start - current end)
-            if next_range["start_ms"] - current["end_ms"] <= gap_threshold:
-                # Merge: Extend end_ms
+            # 갭 확인 (다음 시작 - 현재 끝)
+            if next_range["start_ms"] - current["end_ms"] <= gap_threshold_ms:
+                # 병합: 끝 시간 연장
                 current["end_ms"] = max(current["end_ms"], next_range["end_ms"])
             else:
-                # Push current and start new
-                merged.append({"start_ms": current["start_ms"], "end_ms": current["end_ms"]})
-                current = {"start_ms": next_range["start_ms"], "end_ms": next_range["end_ms"]}
+                # 확정 및 새 구간 시작
+                merged.append(current)
+                current = next_range.copy()
         
-        merged.append({"start_ms": current["start_ms"], "end_ms": current["end_ms"]})
+        merged.append(current)
         return merged
+
+    def _find_duplicate_slide(self, phash: str, des: Optional[np.ndarray]) -> Optional[int]:
+        """
+        [Usage File] Internal Use (_save_slide)
+        [Purpose] 현재 프레임과 과거 저장된 슬라이드들을 비교하여 중복 여부를 판단합니다.
+        
+        [Args]
+        - phash (str): 현재 프레임의 pHash
+        - des (np.ndarray): 현재 프레임의 ORB descriptors
+
+        [Returns]
+        - Optional[int]: 중복된 슬라이드의 saved_slides_history 인덱스. 없으면 None.
+        """
+        if not self.saved_slides_history:
+            return None
+        
+        # 1차 필터: 저장된 모든 슬라이드와 pHash 비교 (O(N))
+        # 해시 인덱스를 쓰지 않고 전체 순회하는 것이 안전함 (해시는 근사값이므로)
+        candidates = []
+        PHASH_THRESHOLD = self.dedup_phash_threshold
+        
+        for idx, slide in enumerate(self.saved_slides_history):
+            dist = self._hamming_distance(phash, slide['phash'])
+            if dist <= PHASH_THRESHOLD:
+                candidates.append((idx, dist))
+        
+        # 거리순 정렬
+        candidates.sort(key=lambda x: x[1])
+        
+        # 2차 정밀 검사: ORB 매칭
+        # 후보가 없더라도 최근 3장은 무조건 비교 (히스토리 로컬성 고려)
+        target_indices = [c[0] for c in candidates]
+        recent_indices = range(max(0, len(self.saved_slides_history) - 3), len(self.saved_slides_history))
+        for ri in recent_indices:
+            if ri not in target_indices:
+                target_indices.append(ri)
+                
+        if des is None or len(des) == 0:
+            # ORB가 없으면 가장 가까운 pHash 후보(매우 유사한 경우)만 리턴
+            if candidates and candidates[0][1] <= 5:
+                return candidates[0][0]
+            return None
+            
+        # matcher 생성 (Hamming distance for binary descriptors)
+        bf = cv2.BFMatcher(cv2.NORM_HAMMING, crossCheck=True)
+        
+        for idx in target_indices:
+            existing_slide = self.saved_slides_history[idx]
+            existing_des = existing_slide.get('des')
+            
+            if existing_des is None or len(existing_des) == 0:
+                continue
+                
+            # ORB 매칭
+            try:
+                matches = bf.match(existing_des, des)
+                if not matches:
+                    continue
+                
+                # 좋은 매칭점 선별
+                # 거리가 가까운 상위 매칭만 사용 or 거리 threshold
+                matches = sorted(matches, key=lambda x: x.distance)
+                good_matches = [m for m in matches if m.distance < self.dedup_orb_distance]
+                
+                # 유사도 점수 산출
+                # 기준: 두 이미지 중 feature 수가 적은 쪽 대비 매칭 비율
+                min_features = min(len(existing_des), len(des))
+                sim_score = len(good_matches) / min_features if min_features > 0 else 0
+                
+                # 판정 기준 (pHash가 가깝고 ORB 유사도가 설정값 이상이면 중복으로 간주)
+                if sim_score >= self.dedup_sim_threshold:
+                    return idx
+            except cv2.error:
+                continue
+                
+        return None
+
+    def _save_slide(self, image: np.ndarray, start_time: float, end_time: float) -> None:
+        """
+        [Usage File] Internal Use
+        [Purpose] 슬라이드 발생 시 중복 검사를 수행하고, 신규 슬라이드면 저장, 중복이면 이력만 업데이트합니다.
+        
+        [Args]
+        - image (np.ndarray): 저장할 슬라이드 이미지 (BGR)
+        - start_time (float): 슬라이드 시작 시간 (초)
+        - end_time (float): 슬라이드 종료 시간 (초)
+        """
+        start_ms = int(start_time * 1000)
+        end_ms = int(end_time * 1000)
+        
+        # 1. 서명(Signature) 생성
+        phash = self._compute_phash(image)
+        
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        kp, des = self.orb.detectAndCompute(gray, None)
+        
+        # 2. 중복 검사 (Online Deduplication)
+        dup_idx = self._find_duplicate_slide(phash, des)
+        
+        if dup_idx is not None:
+            # === Case A: 중복 발견 (Grouping) ===
+            dup_slide = self.saved_slides_history[dup_idx]
+            dup_slide['time_ranges'].append({'start_ms': start_ms, 'end_ms': end_ms})
+            
+            # 로깅
+            # 로깅 - [요청 변경 사항] 파일명(확장자 제거)만 심플하게 출력
+            # 예: DIFFUSION_6_002
+            fname_stem = Path(dup_slide['file_name']).stem
+            pipeline_logger.log("Capture", f"Grouped: {fname_stem}")
+            return
+
+        # === Case B: 신규 슬라이드 ===
+        self.slide_count += 1
+        video_name = Path(self.video_path).stem
+        filename = f"{video_name}_{self.slide_count:03d}.jpg"
+        filepath = os.path.join(self.output_dir, filename)
+        
+        # 파일 저장
+        cv2.imwrite(filepath, image, [cv2.IMWRITE_JPEG_QUALITY, 90])
+        
+        # 이력 등록
+        new_slide = {
+            "id": f"cap_{self.slide_count:03d}", # Unique ID for internal logic
+            "idx": self.slide_count,
+            "file_name": filename,
+            "phash": phash,
+            "des": des, # ORB descriptors 저장 (for future matching)
+            # time_ranges 초기화
+            "time_ranges": [{'start_ms': start_ms, 'end_ms': end_ms}]
+        }
+        self.saved_slides_history.append(new_slide)
+        
+        # 로깅 - [요청 변경 사항] 파일명(확장자 제거)만 심플하게 출력
+        # 예: DIFFUSION_6_003
+        fname_stem = Path(filename).stem
+        pipeline_logger.log("Capture", f"Saved: {fname_stem}")
+
+    def process(self, video_name: str = "video") -> List[dict]:
+        """
+        [Usage File] src/capture/process_content.py
+        [Purpose] 비디오를 프레임 단위로 순차 분석하여 슬라이드 이벤트를 감지하고 처리 결과를 반환합니다.
+        
+        [Returns]
+        - List[dict]: 최종 처리된 슬라이드 목록 (파일명, time_ranges 포함)
+        """
+        cap = cv2.VideoCapture(self.video_path)
+        if not cap.isOpened():
+            print(f"Error: Could not open video {self.video_path}")
+            return []
+
+        fps = cap.get(cv2.CAP_PROP_FPS)
+        check_step = max(1, int(fps * self.sample_interval_sec))
+        frame_idx = 0
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        
+        # 첫 슬라이드 시작 시간
+        self.current_slide_start_time = 0.0
+
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            
+            current_time = frame_idx / fps
+
+            # 정해진 샘플링 주기에만 분석 수행
+            if frame_idx % check_step == 0:
+                gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+                kp = self.orb.detect(gray, None)
+                
+                # 특징점 밀도 맵 생성 (32x32)
+                current_map = np.zeros((32, 32), dtype=np.int32)
+                h, w = gray.shape
+                for k in kp:
+                    x, y = k.pt
+                    ix, iy = int(x * 32 / w), int(y * 32 / h)
+                    if 0 <= ix < 32 and 0 <= iy < 32:
+                        current_map[iy, ix] = 1
+
+                # 지속성(Persistence) 업데이트
+                if self.persistence_streak_map is None:
+                    self.persistence_streak_map = current_map
+                else:
+                    self.persistence_streak_map = (self.persistence_streak_map + 1) * current_map
+
+                # 유효 특징점 카운트
+                confirmed_mask = (self.persistence_streak_map >= self.persistence_threshold)
+                current_text_count = np.sum(confirmed_mask)
+
+                # --- 슬라이드 전환 감지 로직 ---
+                # 1. Start of Slide
+                if self.pending_slide is None and current_text_count > self.min_orb_features:
+                    self.pending_slide = frame.copy()
+                    self.pending_features = current_text_count
+                    self.current_slide_start_time = current_time # 시작 시간 기록
+
+                # 2. End of Slide (Drop Detection)
+                elif self.pending_slide is not None:
+                    if current_text_count < (self.pending_features * (1 - self.persistence_drop_ratio)):
+                        # 슬라이드 종료 확정 -> 저장 및 중복 검사
+                        # 종료 시간은 현재 프레임 시간
+                        self._save_slide(self.pending_slide, self.current_slide_start_time, current_time)
+                        
+                        # 상태 리셋 및 즉시 재탐색 준비
+                        if current_text_count > self.min_orb_features:
+                            # 바로 다음 슬라이드가 이어지는 경우
+                            self.pending_slide = frame.copy()
+                            self.pending_features = current_text_count
+                            self.current_slide_start_time = current_time
+                        else:
+                            self.pending_slide = None
+                            self.pending_features = 0
+                    
+                    # 3. Update Best Frame (정보량이 더 많아지면 갱신)
+                    elif current_text_count > self.pending_features:
+                        self.pending_slide = frame.copy()
+                        self.pending_features = current_text_count
+
+            frame_idx += 1
+
+        # 마지막에 남은 슬라이드 처리
+        if self.pending_slide is not None:
+            self._save_slide(self.pending_slide, self.current_slide_start_time, total_frames / fps)
+
+        cap.release()
+        
+        # === 최종 결과 정리 (Formatting) ===
+        # 1. 첫 번째 슬라이드(시간상 가장 먼저 시작한)의 시작 시간을 0으로 보정 (Persistence Delay 보정)
+        if self.saved_slides_history:
+            # 가장 먼저 저장된 슬라이드(cap_001)의 첫 번째 등장 구간을 0초부터 시작하도록 수정
+            first_slide = self.saved_slides_history[0]
+            if first_slide['time_ranges']:
+                # 리스트의 첫 번째 원소가 가장 이른 시간일 것임 (append 순서)
+                first_slide['time_ranges'][0]['start_ms'] = 0
+
+        # 2. 내부용 키(phash, des 등) 제거 및 time_ranges 병합
+        final_manifest = []
+        for slide in self.saved_slides_history:
+            # 시간 구간 병합 (미세한 끊김 제거)
+            merged_ranges = self._merge_time_ranges(slide['time_ranges'])
+            
+            final_manifest.append({
+                "id": slide['id'],
+                "file_name": slide['file_name'],
+                "time_ranges": merged_ranges
+            })
+            
+        print(f"[Capture] Completed. Total Unique Slides: {len(final_manifest)}")
+        return final_manifest

--- a/src/pipeline/logger.py
+++ b/src/pipeline/logger.py
@@ -1,0 +1,108 @@
+"""
+[Intent]
+전처리 파이프라인의 핵심 로깅 시스템을 제공하는 모듈입니다. 
+오디오 추출, 캡처, STT와 같이 동시에 실행되는 여러 컴포넌트의 상태를 
+동일한 라인에 컬럼(Column) 형태로 평면화하여 실시간 진행 상황을 직관적으로 보여줍니다.
+
+[Usage]
+- run_preprocess_pipeline.py의 병렬 실행 구간에서 각 컴포넌트의 상태 변화를 기록할 때 활용됩니다.
+- src.pipeline.stages 블록 등 각 단계별 실행 함수 내에서 상태 정보를 전파하기 위해 사용됩니다.
+
+[Usage Method]
+- pipeline_logger.log("Audio", "Extracting...") 와 같이 호출하여 상태를 실시간 업데이트합니다.
+- 멀티스레딩 환경에서도 안전하게 출력될 수 있도록 스레드 락(Lock)이 적용되어 있습니다.
+"""
+
+import sys
+import threading
+from typing import Dict, Optional
+
+
+class ColumnLogger:
+    """
+    [Class Purpose]
+    병렬로 진행되는 여러 작업의 상태를 단일 라인 로그로 출력하는 컬럼형 로거 클래스입니다.
+    이전 출력과 동일한 "DONE" 메시지가 반복되는 것을 방지하여 로그의 깔끔함을 유지합니다.
+    """
+
+    def __init__(self):
+        """
+        [Method Purpose]
+        로거의 초기 상태를 설정합니다.
+        
+        [Details]
+        - self.lock: 스레드 안전한 출력을 위한 Lock 객체
+        - self.states: 각 컴포넌트(Audio, Capture, STT)의 현재 상태 메시지 저장소
+        - self.last_printed: DONE 메시지의 중복 출력을 방지하기 위한 마지막 출력 기록
+        """
+        self.lock = threading.Lock()
+        # 기본 컴포넌트 상태 정의
+        self.states = {
+            "Audio": "WAITING",
+            "Capture": "WAITING",
+            "STT": "WAITING"
+        }
+        # 완료(DONE) 상태 중복 출력 방지용 기록
+        self.last_printed: Dict[str, Optional[str]] = {
+            "Audio": None,
+            "Capture": None,
+            "STT": None
+        }
+        # 로그 출력 시 가시성을 위한 컬럼 폭 설정
+        self.max_content_width = 45
+
+    def log(self, component: str, message: str) -> None:
+        """
+        [Usage File] run_preprocess_pipeline.py, stages.py, hybrid_extractor.py 등 전 영역
+        [Purpose] 특정 컴포넌트의 상태를 업데이트하고 전체 컴포넌트의 합산 상태를 화면에 출력합니다.
+        [Connection] 표준 출력(stdout)을 통한 터미널 인터페이스 제공
+        
+        [Args]
+        - component (str): 상태를 업데이트할 컴포넌트 명칭 ("Audio", "Capture", "STT")
+        - message (str): 표시할 상태 메시지 (예: "Extracting...", "DONE (Task: 1.5s)")
+        
+        [Internal Logic]
+        1. 스레드 Lock을 획득하여 공유 상태 접근의 안전성을 보장합니다.
+        2. 입력된 컴포넌트의 상태를 업데이트합니다.
+        3. 각 컴포넌트 순회 시, 이미 완료(DONE)되어 출력된 적이 있는 메시지는 중복 출력을 피하기 위해 생략 조건을 체크합니다.
+        4. 내용이 너무 길면 지정된 폭에 맞춰 생략 기호(...) 처리를 수행합니다.
+        5. 유효한 출력 내용이 존재하는 경우에만 최종 합산 라인을 출력합니다.
+        """
+        with self.lock:
+            # 상태 정보 갱신
+            if component in self.states:
+                self.states[component] = message
+            
+            line_parts = []
+            
+            # 정의된 순서대로 컬럼 생성
+            for name in ["Audio", "Capture", "STT"]:
+                curr_msg = self.states.get(name, "")
+                last_msg = self.last_printed.get(name)
+                
+                # 중복된 DONE 메시지는 출력하지 않음
+                if curr_msg.startswith("DONE") and last_msg == curr_msg:
+                    continue
+                
+                # 신규 DONE 메시지는 기록에 저장
+                if curr_msg.startswith("DONE"):
+                    self.last_printed[name] = curr_msg
+                
+                # 표시용 텍스트 가공 (너무 길면 잘라내기)
+                if len(curr_msg) > self.max_content_width:
+                     disp_msg = curr_msg[:self.max_content_width - 3] + "..."
+                else:
+                     disp_msg = curr_msg
+                
+                column_msg = f"[{name}] {disp_msg}"
+                line_parts.append(column_msg)
+            
+            # 출력할 유효 내용이 있는 경우에만 실행
+            if line_parts:
+                final_line = "    ".join(line_parts)
+                print(final_line)
+                sys.stdout.flush()
+
+
+# [Singleton] 시스템 전체에서 공유되는 로거 인스턴스
+pipeline_logger = ColumnLogger()

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -157,6 +157,23 @@ def run_stt(
     )
 
 
+def run_stt_only(
+    audio_path: Path,
+    output_stt_json: Optional[Path],
+    *,
+    backend: str,
+    write_output: bool = True,
+) -> Dict[str, Any]:
+    """이미 추출된 오디오 파일에 대해 음성 인식을 실행한다."""
+    router = STTRouter(provider=backend)
+    return router.transcribe(
+        audio_path,
+        provider=backend,
+        output_path=output_stt_json if write_output else None,
+        write_output=write_output,
+    )
+
+
 def run_stt_from_storage(
     *,
     audio_storage_key: str,
@@ -222,16 +239,17 @@ def run_capture(
     min_interval: float,
     verbose: bool,
     video_name: str,
-    dedup_enabled: bool = True,
+    dedup_enabled: bool = True,  # Kept for interface compatibility, but no longer used
     write_manifest: bool = True,
 ) -> List[Dict[str, Any]]:
     """슬라이드 캡처를 실행하고 메타데이터 목록을 반환한다."""
+    # Note: dedup_enabled is ignored - new HybridSlideExtractor always uses pHash+ORB dedup
     metadata = process_single_video_capture(
         str(video_path),
         str(output_base),
         scene_threshold=threshold,
+        dedupe_threshold=dedupe_threshold,
         min_interval=min_interval,
-        dedup_enabled=dedup_enabled,
         write_manifest=write_manifest,
     )
     return metadata


### PR DESCRIPTION
## 개요
featurecap의 개선된 Capture 로직을 ReViewFeature에 마이그레이션하고, 병렬 처리 구조를 개선했습니다.

## 문제점 확인
- STT가 Capture 완료 후 순차 실행되어 전처리 시간이 15.1s로 비효율적
- mono-method 로깅이 각 후보마다 개별 줄로 출력되어 터미널이 복잡함
- benchmark report의 Segments 카운트가 0으로 하드코딩됨
- capture settings의 필드명이 featurecap과 불일치 (sensitivity_sim → dedup_sim_threshold)
- run_capture() 시그니처에 제거된 dedup_enabled 파라미터 참조

## 문제 분석 및 해결책
- Audio+STT 체인과 Capture를 ThreadPoolExecutor로 진정한 병렬 실행 구현
- mono-method 로깅을 한 줄 요약 형식으로 통합 (featurecap 스타일)
- stt_payload에서 segments 수를 동적으로 추출하여 benchmark에 반영
- CaptureSettings 필드를 persistence_drop_ratio, dedup_sim_threshold로 업데이트
- run_stt_only() 함수 추가로 이미 추출된 오디오에서 STT 직접 실행 지원

## 수정된 내용
| 파일 | 변경 내용 |
|------|----------|
| `src/run_preprocess_pipeline.py` | `handle_audio_stt_chain()` ∥ `handle_capture()` 병렬 패턴 적용 |
| `src/audio/extract_audio.py` | mono-method 로깅을 한 줄 요약으로 변경 |
| `src/pipeline/stages.py` | `run_stt_only()` 추가, `run_capture()` 시그니처 수정 |
| `src/pipeline/logger.py` | `ColumnLogger` 추가 (신규 파일) |
| `config/capture/settings.yaml` | 새 필드명으로 업데이트 |
| `src/capture/settings.py` | persistence 기반 파라미터로 변경 |
| `src/capture/process_content.py` | 새 settings 인터페이스 적용 |
| `src/capture/tools/hybrid_extractor.py` | pHash+ORB 중복 제거 로직 |
| `config/vlm/settings.yaml` | timeout: 60 추가 |

## 성능 비교
| 항목 | Before | After |
|------|--------|-------|
| 전처리 시간 | 15.1s | **8.1s** (-46%) |
| 병렬 모드 | 깨짐 | 정상 |

## 테스트 결과
- ✅ Preprocess: 3 slides, 42 segments, DB sync 성공
- ✅ Process: VLM (9 results), Sync (7 segments), Summarizer, Judge 완료