### PR TITLE
fix(vlm): DB captures 사용 시 cap_id 우선 참조

### DIFF
--- a/src/vlm/vlm_fusion.py
+++ b/src/vlm/vlm_fusion.py
@@ -51,7 +51,11 @@ def build_fusion_vlm_payload(
         if not file_name:
             continue
 
-        entry_id = item.get("id")
+        # DB captures 테이블은 cap_id 컬럼에 cap_001 형식 저장, id는 UUID (PK)
+        # 로컬 manifest.json은 id 필드에 cap_001 형식 저장
+        # 따라서 cap_id 우선, 없으면 id 사용 (하위 호환성 유지)
+        entry_id = item.get("cap_id") or item.get("id")
+
         
         # New Schema: time_ranges
         time_ranges = item.get("time_ranges")


### PR DESCRIPTION
## 요약
DB에서 captures 데이터를 가져와 VLM 처리할 때, `vlm.json`의 `id` 필드에 `cap_001` 형식 대신 UUID가 저장되는 문제를 수정합니다.

## 변경 사항
- `vlm_fusion.py`: `cap_id` 우선 참조하도록 수정

## 상세 설명

### 문제
| 데이터 소스 | `id` 필드 | `cap_id` 필드 |
|-------------|-----------|---------------|
| 로컬 manifest.json | `cap_001` ✅ | 없음 |
| DB captures 테이블 | UUID (PK) ❌ | `cap_001` ✅ |

`vlm_fusion.py`에서 `item.get("id")`를 호출하면:
- 로컬 manifest 사용 시: `cap_001` 반환 ✅
- DB captures 사용 시: UUID 반환 ❌

### 해결
```python
# 변경 전
entry_id = item.get("id")

# 변경 후
entry_id = item.get("cap_id") or item.get("id")
```

Closes #139