### PR TITLE
[프론트엔드] 채팅 추론 모드(Reasoning Mode) 선택 기능 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,6 +61,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1481,6 +1482,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1534,6 +1536,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1649,6 +1652,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1997,6 +2001,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3697,6 +3702,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3768,6 +3774,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3777,6 +3784,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4374,6 +4382,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4505,6 +4514,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -1,10 +1,11 @@
 import { post, BASE_URL, ApiError } from './client';
 
-export function sendChatMessage({ videoId, message, sessionId }) {
+export function sendChatMessage({ videoId, message, sessionId, reasoningMode }) {
   return post('/api/chat', {
     video_id: videoId,
     message,
     session_id: sessionId || undefined,
+    reasoning_mode: reasoningMode || undefined,
   });
 }
 
@@ -12,6 +13,7 @@ export function streamChatMessage({
   videoId,
   message,
   sessionId,
+  reasoningMode,
   onChunk,
   onSessionId,
   onDone,
@@ -77,6 +79,7 @@ export function streamChatMessage({
           video_id: videoId,
           message,
           session_id: sessionId || undefined,
+          reasoning_mode: reasoningMode || undefined,
         }),
         signal: controller.signal,
       });

--- a/frontend/src/components/ChatBot.jsx
+++ b/frontend/src/components/ChatBot.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { Sparkles, RotateCcw, Bot, Send, Loader2 } from 'lucide-react';
+import { Sparkles, RotateCcw, Bot, Send, Loader2, Zap, Clock, ChevronDown } from 'lucide-react';
 import { streamChatMessage } from '../api/chat';
 import { useVideo } from '../context/VideoContext';
 import MarkdownRenderer from './MarkdownRenderer';
@@ -16,8 +16,36 @@ function ChatBot({ videoId }) {
     ]);
     const [inputValue, setInputValue] = useState('');
     const [sending, setSending] = useState(false);
+    const [reasoningMode, setReasoningMode] = useState('flash'); // 'flash' or 'thinking'
+    const [modeMenuOpen, setModeMenuOpen] = useState(false);
     const messagesContainerRef = useRef(null);
     const abortRef = useRef(null);
+    const modeMenuRef = useRef(null);
+    const textareaRef = useRef(null);
+
+    // Auto-resize textarea
+    const adjustTextareaHeight = () => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+            textarea.style.height = 'auto';
+            const maxHeight = 140; // ~5 lines
+            const newHeight = Math.min(textarea.scrollHeight, maxHeight);
+            textarea.style.height = `${newHeight}px`;
+            // Only show scrollbar when content exceeds maxHeight
+            textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
+        }
+    };
+
+    // Close menu when clicking outside
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (modeMenuRef.current && !modeMenuRef.current.contains(e.target)) {
+                setModeMenuOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, []);
 
     useEffect(() => {
         const container = messagesContainerRef.current;
@@ -53,11 +81,16 @@ function ChatBot({ videoId }) {
         setMessages((prev) => [...prev, userMsg, botMsg]);
         setInputValue('');
         setSending(true);
+        // Reset textarea height
+        if (textareaRef.current) {
+            textareaRef.current.style.height = 'auto';
+        }
 
         abortRef.current = streamChatMessage({
             videoId: videoId || '',
             message: text,
             sessionId: chatSessionId,
+            reasoningMode: reasoningMode,
             onSessionId: (sessionId) => {
                 if (sessionId) setChatSessionId(sessionId);
             },
@@ -184,23 +217,93 @@ function ChatBot({ videoId }) {
 
             {/* Input Area */}
             <div className="p-4 border-t border-[var(--border-color)] bg-surface/95 backdrop-blur">
-                <div className="relative flex items-center">
-                    <input
-                        className="w-full bg-surface-highlight border border-[var(--border-color)] rounded-xl pl-4 pr-12 py-3 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary transition-all placeholder:text-gray-500"
+                <div className="bg-surface-highlight rounded-xl">
+                    {/* Textarea */}
+                    <textarea
+                        ref={textareaRef}
+                        className="w-full bg-transparent border-0 px-4 pt-3 pb-0 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-0 placeholder:text-gray-500 resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-gray-400/50 [&::-webkit-scrollbar-thumb]:rounded-full"
                         placeholder="Ask a question..."
-                        type="text"
+                        rows={1}
                         value={inputValue}
-                        onChange={(e) => setInputValue(e.target.value)}
+                        onChange={(e) => {
+                            setInputValue(e.target.value);
+                            adjustTextareaHeight();
+                        }}
                         onKeyDown={handleKeyDown}
                         disabled={sending}
+                        style={{ minHeight: '24px', maxHeight: '140px', overflowY: 'hidden' }}
                     />
-                    <button
-                        onClick={handleSend}
-                        disabled={sending || !inputValue.trim()}
-                        className="absolute right-2 p-1.5 bg-primary hover:bg-[var(--accent-coral-dark)] rounded-lg text-white transition-colors shadow-lg disabled:opacity-50"
-                    >
-                        <Send className="w-[18px] h-[18px]" />
-                    </button>
+                    {/* Bottom row: Mode selector + Send button */}
+                    <div className="flex items-center justify-between px-2 pb-2">
+                        {/* Mode Selector */}
+                        <div className="relative" ref={modeMenuRef}>
+                            <button
+                                onClick={() => setModeMenuOpen(!modeMenuOpen)}
+                                disabled={sending}
+                                className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-surface transition-all disabled:opacity-50 text-xs"
+                                title={reasoningMode === 'flash' ? '요약 기반 답변' : '원본 분석 답변'}
+                            >
+                                {reasoningMode === 'flash' ? (
+                                    <Zap className="w-3.5 h-3.5 text-yellow-500" />
+                                ) : (
+                                    <Clock className="w-3.5 h-3.5 text-blue-500" />
+                                )}
+                                <span className="font-medium">{reasoningMode === 'flash' ? 'Flash' : 'Thinking'}</span>
+                                <ChevronDown className={`w-3 h-3 transition-transform ${modeMenuOpen ? 'rotate-180' : ''}`} />
+                            </button>
+                            {/* Dropdown Menu (opens upward) */}
+                            {modeMenuOpen && (
+                                <div className="absolute bottom-full left-0 mb-2 w-52 bg-surface border border-[var(--border-color)] rounded-xl shadow-xl overflow-hidden z-50">
+                                    <button
+                                        onClick={() => {
+                                            setReasoningMode('flash');
+                                            setModeMenuOpen(false);
+                                        }}
+                                        className={`w-full flex items-start gap-3 px-3 py-3 text-left hover:bg-surface-highlight transition-colors ${
+                                            reasoningMode === 'flash' ? 'bg-primary/10' : ''
+                                        }`}
+                                    >
+                                        <Zap className={`w-4 h-4 mt-0.5 shrink-0 ${reasoningMode === 'flash' ? 'text-yellow-500' : 'text-gray-400'}`} />
+                                        <div>
+                                            <div className={`text-sm font-medium ${reasoningMode === 'flash' ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}>
+                                                Flash
+                                            </div>
+                                            <div className="text-[11px] text-gray-500 mt-0.5">
+                                                요약 기반 빠른 답변
+                                            </div>
+                                        </div>
+                                    </button>
+                                    <button
+                                        onClick={() => {
+                                            setReasoningMode('thinking');
+                                            setModeMenuOpen(false);
+                                        }}
+                                        className={`w-full flex items-start gap-3 px-3 py-3 text-left hover:bg-surface-highlight transition-colors ${
+                                            reasoningMode === 'thinking' ? 'bg-primary/10' : ''
+                                        }`}
+                                    >
+                                        <Clock className={`w-4 h-4 mt-0.5 shrink-0 ${reasoningMode === 'thinking' ? 'text-blue-500' : 'text-gray-400'}`} />
+                                        <div>
+                                            <div className={`text-sm font-medium ${reasoningMode === 'thinking' ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}>
+                                                Thinking
+                                            </div>
+                                            <div className="text-[11px] text-gray-500 mt-0.5">
+                                                원본 분석 심층 답변
+                                            </div>
+                                        </div>
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+                        {/* Send Button */}
+                        <button
+                            onClick={handleSend}
+                            disabled={sending || !inputValue.trim()}
+                            className="p-2 bg-primary hover:bg-[var(--accent-coral-dark)] rounded-lg text-white transition-colors shadow-sm disabled:opacity-50"
+                        >
+                            <Send className="w-4 h-4" />
+                        </button>
+                    </div>
                 </div>
                 <p className="text-[10px] text-center text-gray-600 mt-2">AI can make mistakes. Check important info.</p>
             </div>


### PR DESCRIPTION
## 변경 사항 (Detailed Changes)

프론트엔드 챗봇 인터페이스에 '추론 모드(Reasoning Mode)' 선택 기능을 추가하여, 사용자가 AI의 응답 방식을 제어할 수 있는 기능을 추가했습니다.

### Frontend
- **ChatBot.jsx**: 
  - 채팅 인터페이스에 추론 모드를 활성화/비활성화할 수 있는 토글 또는 선택 UI가 추가되었습니다.
- **api/chat.js**:
  - 백엔드로 채팅 요청을 보낼 때 `reasoning_mode` 파라미터를 포함하여 전송하도록 API 호출 로직을 업데이트했습니다.
- **package-lock.json**:
  - 의존성 잠금 파일이 업데이트되었습니다.

### Backend
- **process_api.py**:
  - 프론트엔드에서 전달된 추론 모드 파라미터를 처리할 수 있도록 백엔드 로직이 수정되었습니다.