### PR TITLE
feat: VLM ID 구분 + API 로깅 개선

### DIFF
--- a/config/judge/prompts.yaml
+++ b/config/judge/prompts.yaml
@@ -92,6 +92,9 @@ v2:
     }
     ```
 
+    # DATA TO EVALUATE
+    {{SEGMENTS_JSON}}
+
   output_format: |
     # OUTPUT FORMAT
 
@@ -111,10 +114,7 @@ v2:
       }
     ]
     ```
-
-    Input JSON:
-    {{SEGMENTS_JSON}}
-
+    
 # [Legacy] Monolithic Version (v1)
 # - Formerly judge_v4
 # - Monolithic template string
@@ -204,9 +204,6 @@ v1: # Legacy
       "feedback": "한 줄 피드백"
     }
 
-    Input JSON:
-    {{SEGMENTS_JSON}}
-
 # [Optimized] Token Efficient Version (v3)
 # - Goal: Fast evaluation with minimal tokens.
 # - Structure: Concise rubric.
@@ -235,7 +232,7 @@ v3:
        - 6: Simple transcript paraphrase.
        - 0: Incoherent.
 
-    4. **Multimodal** (Ref):
+    4. **Multimodal** (10%):
        - Check `vlm_ids` usage.
 
   protocol: |
@@ -245,7 +242,7 @@ v3:
 
   input_format: |
     JSON Input:
-    { "segment_id": 1, "validation_report": {...}, "source_refs": {...}, "summary": {...} }
+    {{SEGMENTS_JSON}}
 
   output_format: |
     Output JSON Array ONLY:
@@ -256,6 +253,4 @@ v3:
         "feedback": "완벽합니다."
       }
     ]
-    Input:
-    {{SEGMENTS_JSON}}
 

--- a/src/fusion/config.py
+++ b/src/fusion/config.py
@@ -120,7 +120,7 @@ class FinalSummaryConfig(BaseModel):
     """전체 영상을 아우르는 최종 타임라인 요약 생성 설정을 담는다."""
     model_config = ConfigDict(extra="forbid")
 
-    generate_formats: List[Literal["timeline", "tldr_timeline"]]
+    generate_formats: List[Literal["timeline", "tldr_timeline", "tldr"]]
     temperature: float = Field(..., ge=0.0, le=1.0)
     max_chars_per_format: int = Field(..., ge=0)
     style: FinalSummaryStyleConfig

--- a/src/fusion/gemini.py
+++ b/src/fusion/gemini.py
@@ -12,6 +12,14 @@ from .config import ConfigBundle
 
 logger = logging.getLogger(__name__)
 
+
+def _get_timestamp() -> str:
+    """[YYYY-MM-DD | HH:MM:SS.mmm] 형식의 타임스탬프를 반환한다."""
+    from datetime import datetime
+    now = datetime.now()
+    return f"[{now.strftime('%Y-%m-%d | %H:%M:%S')}.{now.strftime('%f')[:3]}]"
+
+
 # [TEST] Safety imports for fix
 from google.genai.types import SafetySetting, HarmCategory, HarmBlockThreshold
 
@@ -156,8 +164,8 @@ def generate_content(
     timeout_sec: int,
     *,
     client_override: Optional[Any] = None,
-) -> str:
-    """Gemini 호출 결과의 텍스트를 반환한다."""
+) -> tuple[str, int]:
+    """Gemini 호출 결과의 텍스트와 토큰 사용량을 반환한다."""
     client = client_override or client_bundle.client
     config = {
         "temperature": temperature,
@@ -166,9 +174,6 @@ def generate_content(
     }
 
     # [TEST-START] Disable Safety Filters to fix 'Failed to extract text' error
-    # Original: (No safety settings, uses defaults)
-    # config['safety_settings'] = None 
-    
     config['safety_settings'] = [
         SafetySetting(category=HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold=HarmBlockThreshold.BLOCK_NONE),
         SafetySetting(category=HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold=HarmBlockThreshold.BLOCK_NONE),
@@ -193,7 +198,12 @@ def generate_content(
             config=config,
         )
         
-    return extract_text_from_response(response)
+    text = extract_text_from_response(response)
+    total_tokens = 0
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        total_tokens = getattr(response.usage_metadata, "total_token_count", 0)
+    
+    return text, total_tokens
 
 
 def run_with_retries(
@@ -205,8 +215,10 @@ def run_with_retries(
     timeout_sec: int,
     max_retries: int,
     backoff_sec: List[int],
-) -> str:
-    """오류 시 Gemini 호출을 재시도한다."""
+    context: str = "",
+    verbose: bool = False,
+) -> tuple[str, int]:
+    """오류 시 Gemini 호출을 재시도하며 결과와 토큰 사용량을 반환한다."""
     clients = getattr(client_bundle, "clients", None) or [client_bundle.client]
     total_clients = len(clients)
     last_error: Optional[Exception] = None
@@ -214,6 +226,10 @@ def run_with_retries(
     for idx, client in enumerate(clients, start=1):
         attempt = 0
         while True:
+            if verbose:
+                label = f" (Key {idx}/{total_clients})" if total_clients > 1 else ""
+                indent = "" if context.lstrip().lower().startswith("batch") else "       "
+                print(f"{_get_timestamp()} {indent}[{context}] Sending request... Attempt {attempt+1}/{max_retries+1}{label}", flush=True)
             try:
                 return generate_content(
                     client_bundle,
@@ -257,10 +273,15 @@ def run_with_retries(
                     except:
                         simplified_msg = error_msg[:100] + "..." if len(error_msg) > 100 else error_msg
 
-                logger.warning(
-                    f"⚠️ Retry {attempt+1}/{max_retries}: {simplified_msg}"
-                )
-                time.sleep(max(sleep_for, 0))
+                indent = "" if context.lstrip().lower().startswith("batch") else "       "
+                prefix = f"[{context}] " if context else ""
+                if simplified_msg:
+                    if verbose:
+                        print(f"{_get_timestamp()} {indent}[{context}] Failed: {simplified_msg}. Retrying in {sleep_for}s...", flush=True)
+                    else:
+                        print(f"{_get_timestamp()} ⚠️ {indent}[{context}] Retry {attempt+1}/{max_retries}: {simplified_msg}", flush=True)
+                
+                time.sleep(sleep_for)
                 attempt += 1
 
     if last_error:


### PR DESCRIPTION
## Summary
- `cap_id` → `vlm_id` 변환으로 원본/VLM 구분 명확화
- API 재시도 로그에 남은 횟수, 대기 시간, 에러 코드 표시
- 배치별 처리 진행 상황 로깅

## 버그 수정
- **summarizer.py**: `run_summarizer()` 함수에 `batch_label: Optional[str] = None` 파라미터 추가 (NameError 수정)
- **judge.py**: `GeminiClientBundle` 임포트 추가 (타입 힌트 에러 수정)

## 변경 파일
- `src/vlm/vlm_engine.py`
- `src/vlm/vlm_fusion.py`
- `src/fusion/gemini.py`
- `src/fusion/summarizer.py`
- `src/fusion/config.py`
- `src/judge/judge.py`
- `config/judge/prompts.yaml`

## Test plan
- [ ] VLM 처리 후 vlm_id 필드 확인
- [ ] API 재시도 시 로그 형식 확인
- [ ] summarizer 배치 처리 시 에러 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)