### PR TITLE
fix: batch progress displays correct total from start

### DIFF
--- a/frontend/src/components/SummaryPanel.jsx
+++ b/frontend/src/components/SummaryPanel.jsx
@@ -120,12 +120,10 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
 
     const stageLabel = (() => {
         const s = (progressInfo.stage || videoStatus || '').toUpperCase();
-        const batchPrefix = progressInfo.total > 1
-            ? `배치 ${Math.min(progressInfo.current + 1, progressInfo.total)}/${progressInfo.total} · `
-            : '';
-        if (s === 'VLM_RUNNING') return `${batchPrefix}AI 분석 진행 중...`;
-        if (s === 'SUMMARY_RUNNING') return `${batchPrefix}요약 생성 중...`;
-        if (s === 'JUDGE_RUNNING') return `${batchPrefix}품질 평가 중...`;
+        // 배치 정보는 오른쪽 진행률 표시에서만 보여줌 (메시지에는 포함하지 않음)
+        if (s === 'VLM_RUNNING') return 'AI 분석 진행 중...';
+        if (s === 'SUMMARY_RUNNING') return '요약 생성 중...';
+        if (s === 'JUDGE_RUNNING') return '품질 평가 중...';
         if (s === 'PREPROCESSING' || s === 'PREPROCESS_DONE') return '전처리 완료, 분석 대기 중...';
         return '영상 분석 중...';
     })();


### PR DESCRIPTION
## Summary
- 프론트엔드 로딩바에서 total_batch가 처음에 1로 표시되던 버그 수정
- 상태 메시지("AI 분석 중...")에서 불필요한 배치 정보 제거

## Changes

### Backend
- `run_process_pipeline.py`: 파이프라인 시작 시 전체 캡처 수 기반으로 `total_batches`를 미리 계산하여 DB에 설정
- `stages.py`: `run_batch_fusion_pipeline`에서 `total_batch`를 덮어쓰지 않고 `current_batch`만 업데이트

### Frontend
- `SummaryPanel.jsx`: `stageLabel`에서 배치 prefix 제거 (배치 정보는 오른쪽 진행률에서만 표시)

## Before/After
| Before | After |
|--------|-------|
| "배치 1/1 · AI 분석 진행 중..." | "AI 분석 진행 중..." |
| 로딩바: 0/1 batches | 로딩바: 0/5 batches (정확한 total) |

## Test plan
- [ ] 배치 모드로 파이프라인 실행 시 처음부터 정확한 total_batch 표시 확인
- [ ] 상태 메시지에 배치 정보가 없는지 확인
- [ ] 오른쪽 진행률 표시에 current/total batches가 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)