### PR TITLE
feat: 비동기 파이프라인 API 및 로딩 UI 개선

### DIFF
--- a/frontend/src/api/videos.js
+++ b/frontend/src/api/videos.js
@@ -23,17 +23,18 @@ export async function uploadToStorage(uploadUrl, file) {
   }
 }
 
-export async function completeUpload(videoId, storageKey) {
+export async function completeUpload(videoId, storageKey, pipelineMode = 'async') {
   return post('/api/videos/upload/complete', {
     video_id: videoId,
     storage_key: storageKey,
+    pipeline_mode: pipelineMode,
   });
 }
 
-export async function uploadVideo(file) {
+export async function uploadVideo(file, pipelineMode = 'async') {
   const { video_id, video_name, upload_url, storage_key } = await initUpload(file);
   await uploadToStorage(upload_url, file);
-  await completeUpload(video_id, storage_key);
+  await completeUpload(video_id, storage_key, pipelineMode);
   return { video_id, video_name, status: 'PREPROCESSING' };
 }
 

--- a/frontend/src/components/SummaryPanel.jsx
+++ b/frontend/src/components/SummaryPanel.jsx
@@ -23,6 +23,8 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
     const [streamKey, setStreamKey] = useState(0);
     const prevBatchRef = useRef(-1);
     const staleFlagRef = useRef(false);
+    const [preprocessInfo, setPreprocessInfo] = useState({ status: null });
+    const [pipelineMode, setPipelineMode] = useState('sequential');
 
     // 비디오 상태 확인: 처리 중인지 판단
     const isProcessing = videoStatus && !['DONE', 'FAILED'].includes((videoStatus).toUpperCase());
@@ -32,33 +34,47 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
         if (!statusData) return;
         setVideoStatus(statusData.video_status);
         setErrorMessage(statusData.error_message || null);
+
+        // 전처리 상태 및 파이프라인 모드 추적
+        const ppJob = statusData.preprocess_job;
+        if (ppJob) setPreprocessInfo({ status: (ppJob.status || '').toUpperCase() });
+        setPipelineMode(statusData.pipeline_mode || 'sequential');
+
         const job = statusData.processing_job;
         if (job) {
             const current = job.progress_current || 0;
-            const total = job.progress_total || 1;
+            const total = job.progress_total || 0;
             const jobStatus = (job.status || '').toUpperCase();
 
-            // Stage-aware progress: each stage adds partial progress within the current batch
-            const stageWeight = { VLM_RUNNING: 0.3, SUMMARY_RUNNING: 0.6, JUDGE_RUNNING: 0.9 };
-            const basePct = total > 0 ? (current / total) * 100 : 0;
-            const batchWidth = total > 0 ? 100 / total : 0;
+            let percent;
+            if (jobStatus === 'DONE') {
+                percent = 100;
+            } else if (total > 0) {
+                // 기존 로직: total이 확정된 경우 (순차 파이프라인)
+                const basePct = (current / total) * 100;
+                const batchWidth = 100 / total;
+                const stageWeight = { VLM_RUNNING: 0.3, SUMMARY_RUNNING: 0.6, JUDGE_RUNNING: 0.9 };
 
-            // Guard: after current_batch increments, status may still show the
-            // previous batch's JUDGE_RUNNING for 1+ poll cycles. Suppress the
-            // stale bonus until status actually moves to the new batch's stage.
-            if (prevBatchRef.current >= 0 && current !== prevBatchRef.current) {
-                staleFlagRef.current = true;
-            }
-            prevBatchRef.current = current;
-            if (staleFlagRef.current && jobStatus !== 'JUDGE_RUNNING') {
-                staleFlagRef.current = false;
-            }
-            const stageBonus = staleFlagRef.current
-                ? 0
-                : (stageWeight[jobStatus] || 0) * batchWidth;
+                // Guard: after current_batch increments, status may still show the
+                // previous batch's JUDGE_RUNNING for 1+ poll cycles.
+                if (prevBatchRef.current >= 0 && current !== prevBatchRef.current) {
+                    staleFlagRef.current = true;
+                }
+                prevBatchRef.current = current;
+                if (staleFlagRef.current && jobStatus !== 'JUDGE_RUNNING') {
+                    staleFlagRef.current = false;
+                }
+                const stageBonus = staleFlagRef.current
+                    ? 0
+                    : (stageWeight[jobStatus] || 0) * batchWidth;
 
-            const percent = jobStatus === 'DONE' ? 100
-                : Math.min(Math.round(basePct + stageBonus), 99);
+                percent = Math.min(Math.round(basePct + stageBonus), 99);
+            } else if (current > 0) {
+                // 비동기 파이프라인: total 미정. 로그 기반 점진 증가 (최대 95%)
+                percent = Math.min(Math.round(95 * (1 - 1 / (1 + current * 0.3))), 95);
+            } else {
+                percent = 0;
+            }
 
             setProgressInfo({
                 current,
@@ -120,7 +136,8 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
 
     const stageLabel = (() => {
         const s = (progressInfo.stage || videoStatus || '').toUpperCase();
-        // 배치 정보는 오른쪽 진행률 표시에서만 보여줌 (메시지에는 포함하지 않음)
+        if (s === 'PROCESSING' && progressInfo.total === 0 && progressInfo.current === 0)
+            return '분석 시작 중...';
         if (s === 'VLM_RUNNING') return 'AI 분석 진행 중...';
         if (s === 'SUMMARY_RUNNING') return '요약 생성 중...';
         if (s === 'JUDGE_RUNNING') return '품질 평가 중...';
@@ -154,6 +171,13 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
                         <div className="absolute inset-0 bg-white/20 w-full animate-[shimmer_2s_infinite] translate-x-[-100%]"></div>
                     </div>
                 </div>
+                {pipelineMode === 'async' && preprocessInfo.status === 'RUNNING' && (
+                    <div className="flex justify-end mt-1">
+                        <span className="text-[10px] text-gray-500 bg-surface-highlight px-2 py-0.5 rounded-full">
+                            전처리 병렬 진행 중
+                        </span>
+                    </div>
+                )}
             </div>
         );
     };

--- a/frontend/src/pages/LoadingPage.css
+++ b/frontend/src/pages/LoadingPage.css
@@ -33,7 +33,7 @@
     -webkit-backdrop-filter: blur(20px);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-2xl);
-    padding: 56px 48px;
+    padding: 32px 40px;
     text-align: center;
     animation: fadeInScale 0.6s ease-out;
     position: relative;
@@ -44,7 +44,7 @@
 .loading-logo {
     font-size: 38px;
     font-weight: 800;
-    margin-bottom: 48px;
+    margin-bottom: 28px;
     letter-spacing: -0.03em;
 }
 
@@ -59,13 +59,13 @@
     color: var(--text-primary);
 }
 
-.loading-spinner {
-    margin-bottom: 36px;
+.page-spinner-wrapper {
+    margin-bottom: 20px;
 }
 
 .spinner {
-    width: 72px;
-    height: 72px;
+    width: 48px;
+    height: 48px;
     border: 3px solid var(--border-color);
     border-top-color: transparent;
     border-radius: 50%;

--- a/frontend/src/pages/LoadingPage.jsx
+++ b/frontend/src/pages/LoadingPage.jsx
@@ -1,33 +1,28 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Upload, Music, FileText, CheckCircle, AlertCircle } from 'lucide-react';
+import { Upload, RefreshCw, CheckCircle, AlertCircle } from 'lucide-react';
 import { useVideo } from '../context/VideoContext';
 import useVideoStatusStream from '../hooks/useVideoStatusStream';
 import './LoadingPage.css';
 
 const STAGES = [
     { name: '영상 업로드 완료', Icon: Upload },
-    { name: '오디오 추출 중...', Icon: Music },
-    { name: 'STT 변환 중...', Icon: FileText },
-    { name: '전처리 완료!', Icon: CheckCircle },
+    { name: '분석 준비 중...', Icon: RefreshCw },
+    { name: '분석 시작!', Icon: CheckCircle },
 ];
 
 function statusToStage(videoStatus) {
     const vs = (videoStatus || '').toUpperCase();
-    if (vs === 'PREPROCESS_DONE' || vs === 'PROCESSING') return 3;
-    if (vs === 'DONE') return 3;
     if (vs === 'FAILED') return -1;
+    if (['PREPROCESS_DONE', 'PROCESSING', 'DONE'].includes(vs)) return 2;
     if (vs === 'PREPROCESSING') return 1;
-    if (vs === 'UPLOADED') return 0;
     return 0;
 }
 
 function stageToProgress(stage) {
     if (stage <= 0) return 5;
-    if (stage === 1) return 25;
-    if (stage === 2) return 55;
-    if (stage >= 3) return 100;
-    return 0;
+    if (stage === 1) return 40;
+    if (stage >= 2) return 100;
 }
 
 function LoadingPage() {
@@ -81,7 +76,7 @@ function LoadingPage() {
     // 전처리 완료 시 분석 페이지로 이동
     useEffect(() => {
         if (done && currentVideoId) {
-            const timer = setTimeout(() => navigate(`/analysis/${currentVideoId}`), 800);
+            const timer = setTimeout(() => navigate(`/analysis/${currentVideoId}`), 300);
             return () => clearTimeout(timer);
         }
     }, [done, currentVideoId, navigate]);
@@ -103,10 +98,9 @@ function LoadingPage() {
 
     useEffect(() => {
         if (!currentVideoId) {
-            if (progress < 25) setStage(0);
-            else if (progress < 55) setStage(1);
-            else if (progress < 85) setStage(2);
-            else setStage(3);
+            if (progress < 40) setStage(0);
+            else if (progress < 90) setStage(1);
+            else setStage(2);
         }
     }, [progress, currentVideoId]);
 

--- a/frontend/src/pages/LoadingPage.jsx
+++ b/frontend/src/pages/LoadingPage.jsx
@@ -115,7 +115,7 @@ function LoadingPage() {
                     <span className="logo-view">View</span>
                 </div>
 
-                <div className="loading-spinner">
+                <div className="page-spinner-wrapper">
                     <div className="spinner"></div>
                 </div>
 

--- a/src/fusion/summarizer.py
+++ b/src/fusion/summarizer.py
@@ -47,7 +47,6 @@ def _build_response_schema() -> Dict[str, Any]:
             "source_type",
             "evidence_refs",
             "confidence",
-            "notes",
         ],
         "properties": {
             "bullet_id": {"type": "string"},
@@ -55,7 +54,6 @@ def _build_response_schema() -> Dict[str, Any]:
             "source_type": source_type_schema,
             "evidence_refs": evidence_schema,
             "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
-            "notes": {"type": "string"},
         },
     }
     definition_schema = {
@@ -66,7 +64,6 @@ def _build_response_schema() -> Dict[str, Any]:
             "source_type",
             "evidence_refs",
             "confidence",
-            "notes",
         ],
         "properties": {
             "term": {"type": "string"},
@@ -74,29 +71,26 @@ def _build_response_schema() -> Dict[str, Any]:
             "source_type": source_type_schema,
             "evidence_refs": evidence_schema,
             "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
-            "notes": {"type": "string"},
         },
     }
     explanation_schema = {
         "type": "object",
-        "required": ["point", "source_type", "evidence_refs", "confidence", "notes"],
+        "required": ["point", "source_type", "evidence_refs", "confidence"],
         "properties": {
             "point": {"type": "string"},
             "source_type": source_type_schema,
             "evidence_refs": evidence_schema,
             "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
-            "notes": {"type": "string"},
         },
     }
     question_schema = {
         "type": "object",
-        "required": ["question", "source_type", "evidence_refs", "confidence", "notes"],
+        "required": ["question", "source_type", "evidence_refs", "confidence"],
         "properties": {
             "question": {"type": "string"},
             "source_type": source_type_schema,
             "evidence_refs": evidence_schema,
             "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
-            "notes": {"type": "string"},
         },
     }
     summary_schema = {

--- a/src/process_api.py
+++ b/src/process_api.py
@@ -129,6 +129,17 @@ def process_pipeline(request: ProcessRequest, background_tasks: BackgroundTasks)
     if not request.video_name and not request.video_id:
         raise HTTPException(status_code=400, detail="video_name or video_id is required.")
 
+    # 이미 PROCESSING 중이면 중복 실행 방지
+    if request.video_id:
+        adapter = get_supabase_adapter()
+        if adapter:
+            video = adapter.get_video(request.video_id)
+            if video and video.get("status") == "PROCESSING":
+                raise HTTPException(
+                    status_code=409,
+                    detail="Pipeline is already running for this video",
+                )
+
     background_tasks.add_task(
         run_processing_pipeline,
         video_name=request.video_name,
@@ -185,6 +196,15 @@ def _build_status_payload(adapter, video_id: str) -> Dict[str, Any]:
                 "started_at": processing_job.get("started_at"),
                 "ended_at": processing_job.get("ended_at"),
             }
+
+    # pipeline_mode 판별: preprocess_job과 processing_job이 동시에 존재하며
+    # preprocess_job이 아직 완료되지 않았으면 async
+    pp_job = result.get("preprocess_job")
+    proc_job = result.get("processing_job")
+    if pp_job and proc_job and (pp_job.get("status") or "").upper() not in ("DONE", ""):
+        result["pipeline_mode"] = "async"
+    else:
+        result["pipeline_mode"] = "sequential"
 
     return result
 
@@ -687,6 +707,7 @@ def init_upload(payload: UploadInitRequest, http_request: Request):
 class UploadCompleteRequest(BaseModel):
     video_id: str
     storage_key: str
+    pipeline_mode: str = "async"
 
 
 class UploadCompleteResponse(BaseModel):
@@ -710,11 +731,18 @@ def complete_upload(
 
     adapter.update_video_status(request.video_id, "PREPROCESSING")
 
-    background_tasks.add_task(
-        _run_full_pipeline_from_storage,
-        request.video_id,
-        request.storage_key,
-    )
+    if request.pipeline_mode == "async":
+        background_tasks.add_task(
+            _run_async_pipeline_from_storage,
+            request.video_id,
+            request.storage_key,
+        )
+    else:
+        background_tasks.add_task(
+            _run_full_pipeline_from_storage,
+            request.video_id,
+            request.storage_key,
+        )
 
     return UploadCompleteResponse(
         video_id=request.video_id,
@@ -811,6 +839,78 @@ def _run_full_pipeline_from_storage(video_id: str, storage_key: str) -> None:
             video_id=video_id,
             sync_to_db=True,
             force_db=True,
+        )
+    except Exception as exc:
+        if adapter:
+            adapter.update_video_status(video_id, "FAILED", error=str(exc))
+    finally:
+        if tmp_dir:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def _run_async_pipeline_from_storage(video_id: str, storage_key: str) -> None:
+    """비동기 파이프라인으로 전처리+분석을 병렬 실행."""
+    import asyncio
+    from src.run_pipeline_demo_async import run_async_demo, _apply_qwen_vlm_overrides, _load_pipeline_defaults, _load_yaml_runtime_defaults
+
+    adapter = get_supabase_adapter()
+    tmp_dir = None
+    try:
+        print("\n" + "=" * 60)
+        print(f"  Re:View API Async Pipeline (Storage): {video_id}")
+        print("=" * 60)
+
+        # 1. Storage에서 임시 디렉토리로 다운로드 (R2 우선, Supabase fallback)
+        tmp_dir = tempfile.mkdtemp()
+        original_name = Path(storage_key).name
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        tmp_filename = f"{timestamp}_{original_name}"
+        tmp_path = Path(tmp_dir) / tmp_filename
+
+        if adapter.s3_client:
+            adapter.s3_client.download_file(adapter.r2_bucket, storage_key, str(tmp_path))
+            print(f"[R2] Downloaded video from {adapter.r2_bucket}/{storage_key}")
+        else:
+            if getattr(adapter, "r2_only", False):
+                raise RuntimeError("R2 storage is required (check R2_* env vars)")
+            file_data = adapter.client.storage.from_("videos").download(storage_key)
+            tmp_path.write_bytes(file_data)
+
+        # 2. 비디오 duration 업데이트
+        _update_video_duration(adapter, video_id, str(tmp_path))
+
+        # 3. Qwen VLM override 적용
+        ROOT = Path(__file__).resolve().parents[1]
+        _apply_qwen_vlm_overrides(ROOT)
+
+        # 4. 비동기 파이프라인 실행
+        defaults = _load_yaml_runtime_defaults()
+        output_base = Path(defaults.get("output_base", "data/outputs"))
+        if not output_base.is_absolute():
+            output_base = (ROOT / output_base).resolve()
+        else:
+            output_base = output_base.resolve()
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+        asyncio.run(
+            run_async_demo(
+                video_path=tmp_path,
+                output_base=output_base,
+                run_id=run_id,
+                stt_backend=str(defaults.get("stt_backend", "clova")),
+                capture_batch_size=int(defaults.get("capture_batch_size", 6)),
+                vlm_parallelism=int(defaults.get("vlm_parallelism", 3)),
+                vlm_inner_concurrency=int(defaults.get("vlm_inner_concurrency", 1)),
+                vlm_batch_size=int(defaults.get("vlm_batch_size", 6)),
+                vlm_show_progress=bool(defaults.get("vlm_show_progress", True)),
+                max_inflight_chunks=8,
+                queue_maxsize=0,
+                strict_batch_order=True,
+                sync_to_db=True,
+                upload_video_to_r2=False,
+                upload_audio_to_r2=True,
+                existing_video_id=video_id,
+            )
         )
     except Exception as exc:
         if adapter:

--- a/src/process_api.py
+++ b/src/process_api.py
@@ -750,47 +750,33 @@ def complete_upload(
     )
 
 
-def _run_full_pipeline_from_storage(video_id: str, storage_key: str) -> None:
-    """
-    스토리지에서 비디오를 다운로드하여 전처리 → 처리 파이프라인을 순차 실행.
-    
-    Purpose:
-        프론트엔드에서 업로드 완료 후 백그라운드에서 실행되는 메인 파이프라인.
-        R2 또는 Supabase Storage에서 비디오를 다운로드하고, 전처리(캡처 추출,
-        STT) 및 처리(VLM, Fusion) 파이프라인을 순차적으로 실행합니다.
-    
-    Storage Integration (R2 Priority):
-        1. adapter.s3_client가 초기화되어 있으면 R2 사용
-        2. R2 미설정 시 Supabase Storage fallback
-        3. 다운로드 경로: {bucket}/{storage_key}
-    
-    Pipeline Flow:
-        1. 스토리지에서 임시 디렉토리로 비디오 다운로드
-        2. run_preprocess_pipeline() 실행 (캡처/오디오 추출, STT)
-        3. run_processing_pipeline() 실행 (VLM, Judge, Fusion)
-        4. 임시 디렉토리 정리
-    
-    Args:
-        video_id (str): 비디오 UUID (DB 레코드 ID)
-        storage_key (str): 스토리지 경로
-            - R2: {video_id}/videos/{filename}
-            - Supabase: {video_id}/{filename}
-    
+def _download_from_storage(adapter, video_id: str, storage_key: str) -> tuple:
+    """스토리지(R2/Supabase)에서 비디오를 임시 디렉토리로 다운로드.
+
     Returns:
-        None (백그라운드 태스크로 실행)
-    
-    Side Effects:
-        - videos.status 업데이트 (PREPROCESSING → PREPROCESS_DONE → PROCESSING → DONE)
-        - captures, stt_results, segments, summaries 테이블에 결과 저장
-        - R2/Supabase Storage에 캡처 이미지, 오디오 업로드
-    
-    Error Handling:
-        - 예외 발생 시 videos.status를 FAILED로 업데이트
-        - 임시 디렉토리는 finally 블록에서 항상 정리
-    
-    Called By:
-        - complete_upload() 엔드포인트 (BackgroundTasks)
+        (tmp_dir, tmp_path): 임시 디렉토리 경로와 다운로드된 파일 경로.
+        호출자가 finally에서 tmp_dir를 정리해야 합니다.
     """
+    tmp_dir = tempfile.mkdtemp()
+    original_name = Path(storage_key).name
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    tmp_filename = f"{timestamp}_{original_name}"
+    tmp_path = Path(tmp_dir) / tmp_filename
+
+    if adapter.s3_client:
+        adapter.s3_client.download_file(adapter.r2_bucket, storage_key, str(tmp_path))
+        print(f"[R2] Downloaded video from {adapter.r2_bucket}/{storage_key}")
+    else:
+        if getattr(adapter, "r2_only", False):
+            raise RuntimeError("R2 storage is required (check R2_* env vars)")
+        file_data = adapter.client.storage.from_("videos").download(storage_key)
+        tmp_path.write_bytes(file_data)
+
+    return tmp_dir, tmp_path
+
+
+def _run_full_pipeline_from_storage(video_id: str, storage_key: str) -> None:
+    """스토리지에서 비디오를 다운로드하여 전처리 → 처리 파이프라인을 순차 실행."""
     from src.run_preprocess_pipeline import run_preprocess_pipeline
 
     adapter = get_supabase_adapter()
@@ -799,24 +785,8 @@ def _run_full_pipeline_from_storage(video_id: str, storage_key: str) -> None:
         print("\n" + "=" * 60)
         print(f"  Re:View API Pipeline (Storage): {video_id}")
         print("=" * 60)
-        
-        # 1. Storage에서 임시 디렉토리로 다운로드 (R2 우선, Supabase fallback)
-        tmp_dir = tempfile.mkdtemp()
-        original_name = Path(storage_key).name
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-        tmp_filename = f"{timestamp}_{original_name}"
-        tmp_path = Path(tmp_dir) / tmp_filename
 
-        if adapter.s3_client:
-            # R2에서 다운로드
-            adapter.s3_client.download_file(adapter.r2_bucket, storage_key, str(tmp_path))
-            print(f"[R2] Downloaded video from {adapter.r2_bucket}/{storage_key}")
-        else:
-            if getattr(adapter, "r2_only", False):
-                raise RuntimeError("R2 storage is required (check R2_* env vars)")
-            # Supabase Storage fallback
-            file_data = adapter.client.storage.from_("videos").download(storage_key)
-            tmp_path.write_bytes(file_data)
+        tmp_dir, tmp_path = _download_from_storage(adapter, video_id, storage_key)
 
         print(f"\n1. Starting 'Preprocessing'...")
         # 2. 전처리
@@ -860,21 +830,7 @@ def _run_async_pipeline_from_storage(video_id: str, storage_key: str) -> None:
         print(f"  Re:View API Async Pipeline (Storage): {video_id}")
         print("=" * 60)
 
-        # 1. Storage에서 임시 디렉토리로 다운로드 (R2 우선, Supabase fallback)
-        tmp_dir = tempfile.mkdtemp()
-        original_name = Path(storage_key).name
-        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-        tmp_filename = f"{timestamp}_{original_name}"
-        tmp_path = Path(tmp_dir) / tmp_filename
-
-        if adapter.s3_client:
-            adapter.s3_client.download_file(adapter.r2_bucket, storage_key, str(tmp_path))
-            print(f"[R2] Downloaded video from {adapter.r2_bucket}/{storage_key}")
-        else:
-            if getattr(adapter, "r2_only", False):
-                raise RuntimeError("R2 storage is required (check R2_* env vars)")
-            file_data = adapter.client.storage.from_("videos").download(storage_key)
-            tmp_path.write_bytes(file_data)
+        tmp_dir, tmp_path = _download_from_storage(adapter, video_id, storage_key)
 
         # 2. 비디오 duration 업데이트
         _update_video_duration(adapter, video_id, str(tmp_path))

--- a/src/vlm/vlm_fusion.py
+++ b/src/vlm/vlm_fusion.py
@@ -152,15 +152,15 @@ def build_fusion_vlm_payload(
         # time_ranges 정렬 (start_ms 기준)
         sorted_ranges = sorted(img_data["time_ranges"], key=lambda x: x["start_ms"])
             
-        vlm_id = img_data["cap_id"]
-        if vlm_id.startswith("cap_"):
+        vlm_id = img_data.get("cap_id")
+        if vlm_id and vlm_id.startswith("cap_"):
             vlm_id = vlm_id.replace("cap_", "vlm_")
         else:
             vlm_id = f"vlm_{idx:03d}"
-            
+
         items.append({
             "id": vlm_id,
-            "cap_id": img_data["cap_id"],
+            "cap_id": img_data.get("cap_id") or f"cap_{idx:03d}",
             "extracted_text": image_text[file_name],
             "time_ranges": sorted_ranges,
             "timestamp_ms": img_data["first_start_ms"]


### PR DESCRIPTION
## 주요 변경 사항

### 1. 비동기 파이프라인 API 구현 (`process_api.py`)
- `_run_async_pipeline_from_storage()` 함수 추가: R2 스토리지에서 비디오 다운로드 후 비동기 파이프라인 실행
- `complete_upload` 엔드포인트에 `pipeline_mode` 파라미터 추가 (기본값: `async`)
- 파이프라인 모드에 따라 순차/비동기 실행 분기 처리
- 중복 실행 방지: PROCESSING 상태일 경우 409 에러 반환
- 상태 응답에 `pipeline_mode` 필드 추가 (`async`/`sequential` 구분)

### 2. Summarizer JSON 스키마 버그 수정 (`summarizer.py`)
- `notes` 필드를 JSON 응답 스키마에서 제거
- 원인: 프롬프트에서는 `notes` 필드를 제거했으나, JSON 검증 스키마에는 남아있어 검증 실패
- 수정 대상: `bullet_schema`, `definition_schema`, `explanation_schema`, `question_schema`

### 3. 경로 처리 오류 해결 (`stages.py`)
- `_safe_rel_to()` 헬퍼 함수 추가: 상대 경로 변환 시 발생하는 예외 방지
- `run_batch_fusion_pipeline()`에서 경로 정규화 로직 강화
  - `repo_root`, `video_root`, `captures_dir`, `stt_json`, `manifest_json` 경로를 절대 경로로 변환
  - 상대/절대 경로 혼용으로 인한 Windows Path 오류 해결
- VLM JSON 재사용 검증 강화: `id`, `cap_id` 필수 필드 검증 추가
- 로그 출력 시 `relative_to()` 대신 `_safe_rel_to()` 사용하여 안정성 확보

### 4. 비동기 파이프라인 연동 (`run_pipeline_demo_async.py`)
- `existing_video_id` 파라미터 추가: 기존 `video_id` 재사용 가능
- API에서 이미 생성된 `video_id`를 파이프라인에 전달하여 중복 생성 방지

### 5. VLM Fusion 안정성 개선 (`vlm_fusion.py`)
- `cap_id` 필드 접근 시 `.get()` 메서드 사용으로 KeyError 방지
- `cap_id` 누락 시 기본값 생성 (`cap_{idx:03d}`)

### 6. 프론트엔드 비동기 UI 지원
- **LoadingPage**: 단계를 3단계로 간소화 (업로드 → 준비 → 시작)
- **SummaryPanel**: 비동기 파이프라인 진행률 표시 로직 추가
  - `total` 미정 시 로그 기반 점진적 증가 (최대 95%)
  - 전처리 병렬 진행 상태 표시 배지 추가
- **videos.js**: `pipelineMode` 파라미터 지원

### 7. 로딩 페이지 CSS 수정
- CSS 클래스명 충돌 해결 및 레이아웃 최적화

## 관련 Issue
Closes #176 