### PR TITLE
feat(video): 사용자 동영상 삭제(DB+R2) 및 접근 권한/미디어 접근 보강

### DIFF
--- a/frontend/src/api/chat.js
+++ b/frontend/src/api/chat.js
@@ -1,4 +1,5 @@
 import { post, BASE_URL, ApiError } from './client';
+import { supabase } from '../lib/supabase';
 
 export function sendChatMessage({ videoId, message, sessionId, reasoningMode }) {
   return post('/api/chat', {
@@ -78,9 +79,21 @@ export function streamChatMessage({
 
   const start = async () => {
     try {
+      const headers = { 'Content-Type': 'application/json' };
+      if (supabase) {
+        try {
+          const { data: { session } } = await supabase.auth.getSession();
+          if (session?.access_token) {
+            headers.Authorization = `Bearer ${session.access_token}`;
+          }
+        } catch {
+          // ignore auth header errors
+        }
+      }
+
       const res = await fetch(`${BASE_URL}/api/chat/stream`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({
           video_id: videoId,
           message,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -56,6 +56,10 @@ export function post(url, body) {
   });
 }
 
+export function del(url) {
+  return request(url, { method: 'DELETE' });
+}
+
 export function postForm(url, formData) {
   return getAuthHeaders().then((authHeaders) =>
     fetch(BASE_URL + url, { method: 'POST', body: formData, headers: { ...authHeaders } })

--- a/frontend/src/api/videos.js
+++ b/frontend/src/api/videos.js
@@ -1,4 +1,4 @@
-import { get, post, BASE_URL } from './client';
+import { get, post, del, BASE_URL } from './client';
 import { supabase } from '../lib/supabase';
 
 // ---------------------------------------------------------------------------
@@ -97,14 +97,38 @@ export function getVideoProgress(videoId) {
   return get(`/videos/${videoId}/progress`);
 }
 
-export function getVideoStreamUrl(videoId) {
-  return `${BASE_URL}/api/videos/${videoId}/stream`;
-}
-
-export function getThumbnailUrl(videoId) {
-  return `${BASE_URL}/api/videos/${videoId}/thumbnail`;
-}
-
 export function restartProcessing(videoId) {
   return post('/process', { video_id: videoId });
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+export function deleteVideo(videoId) {
+  return del(`/api/videos/${videoId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Media Ticket (for <video>/<img> src without Authorization header)
+// ---------------------------------------------------------------------------
+
+export function getMediaTicket() {
+  return post('/api/media/ticket', {});
+}
+
+// ---------------------------------------------------------------------------
+// Media URLs
+// ---------------------------------------------------------------------------
+
+export function getVideoStreamUrl(videoId, ticket) {
+  if (!videoId) return null;
+  const q = ticket ? `?ticket=${encodeURIComponent(ticket)}` : '';
+  return `${BASE_URL}/api/videos/${videoId}/stream${q}`;
+}
+
+export function getThumbnailUrl(videoId, ticket) {
+  if (!videoId) return null;
+  const q = ticket ? `?ticket=${encodeURIComponent(ticket)}` : '';
+  return `${BASE_URL}/api/videos/${videoId}/thumbnail${q}`;
 }

--- a/frontend/src/components/ConfirmModal.css
+++ b/frontend/src/components/ConfirmModal.css
@@ -1,0 +1,166 @@
+.confirm-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: scale(0.95) translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+.confirm-modal {
+    position: relative;
+    width: 100%;
+    max-width: 400px;
+    padding: 32px;
+    background: var(--bg-card-solid);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-xl);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+    animation: slideUp 0.25s ease-out;
+    text-align: center;
+}
+
+.confirm-modal-close {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    border-radius: 8px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.confirm-modal-close:hover {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+}
+
+.confirm-modal-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 64px;
+    height: 64px;
+    margin-bottom: 20px;
+    border-radius: 50%;
+    background: rgba(239, 68, 68, 0.1);
+    color: #ef4444;
+}
+
+.confirm-modal--danger .confirm-modal-icon {
+    background: rgba(239, 68, 68, 0.1);
+    color: #ef4444;
+}
+
+.confirm-modal--warning .confirm-modal-icon {
+    background: rgba(245, 158, 11, 0.1);
+    color: #f59e0b;
+}
+
+.confirm-modal-title {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.confirm-modal-message {
+    margin: 0 0 28px 0;
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    white-space: pre-line;
+}
+
+.confirm-modal-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+
+.confirm-modal-btn {
+    flex: 1;
+    max-width: 140px;
+    padding: 12px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.confirm-modal-btn--cancel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+}
+
+.confirm-modal-btn--cancel:hover {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+}
+
+.confirm-modal-btn--confirm {
+    border: none;
+    color: white;
+}
+
+.confirm-modal-btn--danger {
+    background: linear-gradient(135deg, #ef4444, #dc2626);
+    box-shadow: 0 4px 14px rgba(239, 68, 68, 0.35);
+}
+
+.confirm-modal-btn--danger:hover {
+    background: linear-gradient(135deg, #dc2626, #b91c1c);
+    box-shadow: 0 6px 20px rgba(239, 68, 68, 0.45);
+    transform: translateY(-1px);
+}
+
+.confirm-modal-btn--warning {
+    background: linear-gradient(135deg, #f59e0b, #d97706);
+    box-shadow: 0 4px 14px rgba(245, 158, 11, 0.35);
+}
+
+.confirm-modal-btn--warning:hover {
+    background: linear-gradient(135deg, #d97706, #b45309);
+    box-shadow: 0 6px 20px rgba(245, 158, 11, 0.45);
+    transform: translateY(-1px);
+}
+
+.confirm-modal-btn:active {
+    transform: scale(0.98);
+}

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import './ConfirmModal.css';
+
+function ConfirmModal({ isOpen, title, message, confirmText = '삭제', cancelText = '취소', onConfirm, onCancel, variant = 'danger' }) {
+    const modalRef = useRef(null);
+    const confirmButtonRef = useRef(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            confirmButtonRef.current?.focus();
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = '';
+        }
+        return () => {
+            document.body.style.overflow = '';
+        };
+    }, [isOpen]);
+
+    useEffect(() => {
+        const handleEscape = (e) => {
+            if (e.key === 'Escape' && isOpen) {
+                onCancel();
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+        return () => document.removeEventListener('keydown', handleEscape);
+    }, [isOpen, onCancel]);
+
+    const handleBackdropClick = (e) => {
+        if (e.target === modalRef.current) {
+            onCancel();
+        }
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="confirm-modal-backdrop" ref={modalRef} onClick={handleBackdropClick}>
+            <div className={`confirm-modal confirm-modal--${variant}`}>
+                <button className="confirm-modal-close" onClick={onCancel} aria-label="닫기">
+                    <X className="w-5 h-5" />
+                </button>
+
+                <div className="confirm-modal-icon">
+                    <AlertTriangle className="w-8 h-8" />
+                </div>
+
+                <h2 className="confirm-modal-title">{title}</h2>
+                <p className="confirm-modal-message">{message}</p>
+
+                <div className="confirm-modal-actions">
+                    <button className="confirm-modal-btn confirm-modal-btn--cancel" onClick={onCancel}>
+                        {cancelText}
+                    </button>
+                    <button
+                        ref={confirmButtonRef}
+                        className={`confirm-modal-btn confirm-modal-btn--confirm confirm-modal-btn--${variant}`}
+                        onClick={onConfirm}
+                    >
+                        {confirmText}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default ConfirmModal;

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -9,12 +9,28 @@ function Sidebar() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        listVideos()
-            .then((data) => {
-                setRecentVideos((data.videos || []).slice(0, 5));
-            })
-            .catch(() => {})
-            .finally(() => setLoading(false));
+        let mounted = true;
+
+        const refresh = () => {
+            setLoading(true);
+            listVideos()
+                .then((data) => {
+                    if (!mounted) return;
+                    setRecentVideos((data.videos || []).slice(0, 5));
+                })
+                .catch(() => {})
+                .finally(() => {
+                    if (!mounted) return;
+                    setLoading(false);
+                });
+        };
+
+        refresh();
+        window.addEventListener('videos:changed', refresh);
+        return () => {
+            mounted = false;
+            window.removeEventListener('videos:changed', refresh);
+        };
     }, []);
 
     const getStatusIcon = (status) => {

--- a/frontend/src/components/VideoCard.css
+++ b/frontend/src/components/VideoCard.css
@@ -122,43 +122,28 @@
 }
 
 .video-delete {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 34px;
-    height: 34px;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.6);
-    backdrop-filter: blur(8px);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    border-radius: 10px;
-    color: rgba(255, 255, 255, 0.9);
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    color: var(--text-muted);
     cursor: pointer;
-    opacity: 0;
-    transition: opacity 0.25s ease, transform 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
-}
-
-.video-card:hover .video-delete {
-    opacity: 1;
+    transition: all 0.2s ease;
 }
 
 .video-delete:hover {
-    background: rgba(239, 68, 68, 0.9);
-    border-color: rgba(239, 68, 68, 0.5);
-    transform: scale(1.05);
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #ef4444;
 }
 
-.video-delete[aria-disabled="true"] {
-    opacity: 0.35;
-    cursor: not-allowed;
-}
-
-.video-delete[aria-disabled="true"]:hover {
-    background: rgba(0, 0, 0, 0.6);
-    border-color: rgba(255, 255, 255, 0.12);
-    transform: none;
+.video-delete:active {
+    transform: scale(0.95);
 }
 
 .status-pulse {
@@ -170,9 +155,18 @@
 }
 
 .video-info {
-    padding: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 18px;
     background: var(--bg-card-solid);
     transition: background-color 0.3s ease;
+}
+
+.video-info-content {
+    flex: 1;
+    min-width: 0;
 }
 
 .video-title {

--- a/frontend/src/components/VideoCard.css
+++ b/frontend/src/components/VideoCard.css
@@ -121,6 +121,46 @@
     border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.video-delete {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    color: rgba(255, 255, 255, 0.9);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.25s ease, transform 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+}
+
+.video-card:hover .video-delete {
+    opacity: 1;
+}
+
+.video-delete:hover {
+    background: rgba(239, 68, 68, 0.9);
+    border-color: rgba(239, 68, 68, 0.5);
+    transform: scale(1.05);
+}
+
+.video-delete[aria-disabled="true"] {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
+.video-delete[aria-disabled="true"]:hover {
+    background: rgba(0, 0, 0, 0.6);
+    border-color: rgba(255, 255, 255, 0.12);
+    transform: none;
+}
+
 .status-pulse {
     width: 6px;
     height: 6px;

--- a/frontend/src/components/VideoCard.jsx
+++ b/frontend/src/components/VideoCard.jsx
@@ -19,7 +19,6 @@ function VideoCard({ id, title, thumbnail, thumbnailVideoId, duration, date, sta
 
     // Use thumbnail prop if provided (legacy), otherwise use API
     const imgSrc = thumbnail || (thumbnailVideoId ? getThumbnailUrl(thumbnailVideoId, mediaTicket) : null);
-    const canDelete = status === 'done';
     const showImage = imgSrc && failedSrc !== imgSrc;
 
     return (
@@ -28,13 +27,11 @@ function VideoCard({ id, title, thumbnail, thumbnailVideoId, duration, date, sta
                 <button
                     type="button"
                     className="video-delete"
-                    aria-disabled={!canDelete}
-                    title={canDelete ? 'Delete video' : 'Video is still processing'}
-                    aria-label="Delete video"
+                    title={status === 'done' ? '삭제' : '처리 중인 영상은 삭제가 제한될 수 있습니다'}
+                    aria-label="영상 삭제"
                     onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        if (!canDelete) return;
                         onDelete(id);
                     }}
                 >

--- a/frontend/src/components/VideoCard.jsx
+++ b/frontend/src/components/VideoCard.jsx
@@ -23,21 +23,6 @@ function VideoCard({ id, title, thumbnail, thumbnailVideoId, duration, date, sta
 
     return (
         <Link to={`/analysis/${id}`} className="video-card">
-            {onDelete && (
-                <button
-                    type="button"
-                    className="video-delete"
-                    title={status === 'done' ? '삭제' : '처리 중인 영상은 삭제가 제한될 수 있습니다'}
-                    aria-label="영상 삭제"
-                    onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        onDelete(id);
-                    }}
-                >
-                    <Trash2 className="w-4 h-4" />
-                </button>
-            )}
             <div className="video-thumbnail">
                 {showImage ? (
                     <img src={imgSrc} alt={title} onError={() => setFailedSrc(imgSrc)} />
@@ -70,8 +55,25 @@ function VideoCard({ id, title, thumbnail, thumbnailVideoId, duration, date, sta
                 </span>
             </div>
             <div className="video-info">
-                <h3 className="video-title">{title}</h3>
-                <span className="video-date"><Calendar className="w-3 h-3" />{date}</span>
+                <div className="video-info-content">
+                    <h3 className="video-title">{title}</h3>
+                    <span className="video-date"><Calendar className="w-3 h-3" />{date}</span>
+                </div>
+                {onDelete && (
+                    <button
+                        type="button"
+                        className="video-delete"
+                        title="삭제"
+                        aria-label="영상 삭제"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onDelete(id, status);
+                        }}
+                    >
+                        <Trash2 className="w-4 h-4" />
+                    </button>
+                )}
             </div>
         </Link>
     );

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,11 +1,52 @@
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
+import { getMediaTicket } from '../api/videos';
 
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
     const [loading, setLoading] = useState(true);
+    const [mediaTicket, setMediaTicket] = useState(null);
+    const [mediaTicketExpAt, setMediaTicketExpAt] = useState(0);
+    const mediaTicketTimerRef = useRef(null);
+
+    const refreshMediaTicket = async () => {
+        if (mediaTicketTimerRef.current) {
+            clearTimeout(mediaTicketTimerRef.current);
+            mediaTicketTimerRef.current = null;
+        }
+
+        try {
+            const data = await getMediaTicket();
+            const ticket = data?.ticket;
+            const expiresIn = Number(data?.expires_in || 0);
+
+            if (!ticket || !expiresIn) {
+                throw new Error('Invalid media ticket response');
+            }
+
+            const expAt = Date.now() + expiresIn * 1000;
+            setMediaTicket(ticket);
+            setMediaTicketExpAt(expAt);
+
+            // Refresh slightly before expiry to keep <video>/<img> URLs working.
+            const refreshInMs = Math.max(10_000, expiresIn * 1000 - 30_000);
+            mediaTicketTimerRef.current = setTimeout(() => {
+                refreshMediaTicket();
+            }, refreshInMs);
+
+            return ticket;
+        } catch {
+            setMediaTicket(null);
+            setMediaTicketExpAt(0);
+            // Best-effort retry later (network hiccup, cold start, etc.)
+            mediaTicketTimerRef.current = setTimeout(() => {
+                refreshMediaTicket();
+            }, 30_000);
+            return null;
+        }
+    };
 
     useEffect(() => {
         if (!supabase) {
@@ -17,16 +58,35 @@ export function AuthProvider({ children }) {
         supabase.auth.getSession().then(({ data: { session } }) => {
             setUser(session?.user ?? null);
             setLoading(false);
+            if (session?.user) {
+                refreshMediaTicket();
+            }
         });
 
         // 인증 상태 변경 리스너
         const { data: { subscription } } = supabase.auth.onAuthStateChange(
             (_event, session) => {
                 setUser(session?.user ?? null);
+                if (session?.user) {
+                    refreshMediaTicket();
+                } else {
+                    setMediaTicket(null);
+                    setMediaTicketExpAt(0);
+                    if (mediaTicketTimerRef.current) {
+                        clearTimeout(mediaTicketTimerRef.current);
+                        mediaTicketTimerRef.current = null;
+                    }
+                }
             }
         );
 
-        return () => subscription.unsubscribe();
+        return () => {
+            subscription.unsubscribe();
+            if (mediaTicketTimerRef.current) {
+                clearTimeout(mediaTicketTimerRef.current);
+                mediaTicketTimerRef.current = null;
+            }
+        };
     }, []);
 
     const signIn = async (email, password) => {
@@ -78,6 +138,9 @@ export function AuthProvider({ children }) {
         <AuthContext.Provider value={{
             user,
             loading,
+            mediaTicket,
+            mediaTicketExpAt,
+            refreshMediaTicket,
             signIn,
             signUp,
             signOut,

--- a/frontend/src/hooks/useVideoStatusStream.js
+++ b/frontend/src/hooks/useVideoStatusStream.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { BASE_URL } from '../api/client';
+import { supabase } from '../lib/supabase';
 
 /**
  * SSE를 통해 비디오 상태 및 요약을 실시간으로 스트리밍합니다.
@@ -104,9 +105,21 @@ export default function useVideoStatusStream(
     controllerRef.current = controller;
 
     try {
+      const headers = { Accept: 'text/event-stream' };
+      if (supabase) {
+        try {
+          const { data: { session } } = await supabase.auth.getSession();
+          if (session?.access_token) {
+            headers.Authorization = `Bearer ${session.access_token}`;
+          }
+        } catch {
+          // ignore auth header errors
+        }
+      }
+
       const res = await fetch(`${BASE_URL}/videos/${videoId}/status/stream`, {
         method: 'GET',
-        headers: { Accept: 'text/event-stream' },
+        headers,
         signal: controller.signal,
       });
 

--- a/frontend/src/pages/AnalysisPage.jsx
+++ b/frontend/src/pages/AnalysisPage.jsx
@@ -49,7 +49,7 @@ function AnalysisPage() {
         v.currentTime = timeMs / 1000;
         setCurrentPlaybackMs(timeMs);
         if (v.paused) {
-            v.play().catch(() => {});
+            v.play().catch(() => { });
         }
     }, []);
 
@@ -58,13 +58,11 @@ function AnalysisPage() {
             setCurrentVideoId(videoId);
             getVideoStatus(videoId)
                 .then((data) => setVideoInfo(data))
-                .catch(() => {});
+                .catch(() => { });
         }
     }, [videoId, setCurrentVideoId]);
 
-    const videoName = videoInfo?.video_status
-        ? (videoInfo.video_name || videoId)
-        : videoId;
+    const videoName = videoInfo?.video_name || (videoInfo ? videoId : '로딩 중...');
 
     const statusLabel = videoInfo?.video_status || 'Loading';
 
@@ -84,7 +82,17 @@ function AnalysisPage() {
                         <a href="/" className="text-gray-400 text-sm font-medium hover:text-[var(--text-primary)] transition-colors">Library</a>
                         <ChevronRight className="w-4 h-4 text-gray-400" />
                         <div className="flex items-center gap-2">
-                            <span className="text-[var(--text-primary)] text-sm font-medium truncate max-w-[200px]">{videoName}</span>
+                            {videoInfo ? (
+                                <span className="text-[var(--text-primary)] text-sm font-medium truncate max-w-[200px]">{videoName}</span>
+                            ) : (
+                                <span className="text-gray-400 text-sm font-medium">
+                                    <span className="inline-flex">
+                                        <span className="animate-pulse">.</span>
+                                        <span className="animate-pulse" style={{ animationDelay: '0.2s' }}>.</span>
+                                        <span className="animate-pulse" style={{ animationDelay: '0.4s' }}>.</span>
+                                    </span>
+                                </span>
+                            )}
                             <span className="bg-primary/20 text-primary text-[10px] font-bold px-1.5 py-0.5 rounded uppercase tracking-wide">{statusLabel}</span>
                         </div>
                     </div>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import Header from '../components/Header';
 import VideoCard from '../components/VideoCard';
 import UploadArea from '../components/UploadArea';
+import ConfirmModal from '../components/ConfirmModal';
 import { Library, Loader2 } from 'lucide-react';
 import { listVideos, deleteVideo } from '../api/videos';
 import './HomePage.css';
@@ -35,6 +36,7 @@ function HomePage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [filter, setFilter] = useState('all');
+    const [deleteTarget, setDeleteTarget] = useState(null);
 
     useEffect(() => {
         setLoading(true);
@@ -47,28 +49,30 @@ function HomePage() {
             .finally(() => setLoading(false));
     }, []);
 
-    const handleDelete = async (videoId) => {
-        const target = (videos || []).find((v) => v.id === videoId);
-        const uiStatus = mapStatus(target?.status);
+    const handleDeleteRequest = (videoId, status) => {
+        setDeleteTarget({ id: videoId, status });
+    };
 
-        const message = uiStatus === 'progress'
-            ? '이 영상은 진행 중으로 표시됩니다.\n실제로 작업이 멈춘 상태(stuck)라면 삭제가 진행될 수 있습니다.\n삭제할까요? (되돌릴 수 없습니다)'
-            : '이 영상을 삭제할까요? (되돌릴 수 없습니다)';
-
-        const ok = window.confirm(message);
-        if (!ok) return;
+    const handleDeleteConfirm = async () => {
+        if (!deleteTarget) return;
 
         try {
-            await deleteVideo(videoId);
-            setVideos((prev) => (prev || []).filter((v) => v.id !== videoId));
+            await deleteVideo(deleteTarget.id);
+            setVideos((prev) => (prev || []).filter((v) => v.id !== deleteTarget.id));
             window.dispatchEvent(new Event('videos:changed'));
         } catch (err) {
             if (err?.status === 409) {
                 setError('아직 처리 중인 영상은 삭제할 수 없습니다.');
-                return;
+            } else {
+                setError(err?.message || 'Failed to delete video');
             }
-            setError(err?.message || 'Failed to delete video');
+        } finally {
+            setDeleteTarget(null);
         }
+    };
+
+    const handleDeleteCancel = () => {
+        setDeleteTarget(null);
     };
 
     const filtered = videos.filter((v) => {
@@ -159,13 +163,26 @@ function HomePage() {
                                     duration={formatDuration(video.duration_sec)}
                                     date={formatDate(video.created_at)}
                                     status={mapStatus(video.status)}
-                                    onDelete={handleDelete}
+                                    onDelete={handleDeleteRequest}
                                 />
                             </div>
                         ))}
                     </div>
                 </section>
             </main>
+
+            <ConfirmModal
+                isOpen={deleteTarget !== null}
+                title="영상 삭제"
+                message={deleteTarget?.status === 'progress'
+                    ? '이 영상은 현재 처리 중입니다.\n정말 삭제하시겠습니까?'
+                    : '이 영상을 삭제하시겠습니까?\n삭제된 영상은 복구할 수 없습니다.'}
+                confirmText="삭제"
+                cancelText="취소"
+                onConfirm={handleDeleteConfirm}
+                onCancel={handleDeleteCancel}
+                variant="danger"
+            />
 
             {/* Footer */}
             <footer className="home-footer">

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,7 +3,7 @@ import Header from '../components/Header';
 import VideoCard from '../components/VideoCard';
 import UploadArea from '../components/UploadArea';
 import { Library, Loader2 } from 'lucide-react';
-import { listVideos } from '../api/videos';
+import { listVideos, deleteVideo } from '../api/videos';
 import './HomePage.css';
 
 // DB 상태 → UI 상태 매핑
@@ -46,6 +46,19 @@ function HomePage() {
             .catch((err) => setError(err.message || 'Failed to load videos'))
             .finally(() => setLoading(false));
     }, []);
+
+    const handleDelete = async (videoId) => {
+        const ok = window.confirm('이 영상을 삭제할까요? (되돌릴 수 없습니다)');
+        if (!ok) return;
+
+        try {
+            await deleteVideo(videoId);
+            setVideos((prev) => (prev || []).filter((v) => v.id !== videoId));
+            window.dispatchEvent(new Event('videos:changed'));
+        } catch (err) {
+            setError(err?.message || 'Failed to delete video');
+        }
+    };
 
     const filtered = videos.filter((v) => {
         if (filter === 'all') return true;
@@ -135,6 +148,7 @@ function HomePage() {
                                     duration={formatDuration(video.duration_sec)}
                                     date={formatDate(video.created_at)}
                                     status={mapStatus(video.status)}
+                                    onDelete={handleDelete}
                                 />
                             </div>
                         ))}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -48,7 +48,14 @@ function HomePage() {
     }, []);
 
     const handleDelete = async (videoId) => {
-        const ok = window.confirm('이 영상을 삭제할까요? (되돌릴 수 없습니다)');
+        const target = (videos || []).find((v) => v.id === videoId);
+        const uiStatus = mapStatus(target?.status);
+
+        const message = uiStatus === 'progress'
+            ? '이 영상은 진행 중으로 표시됩니다.\n실제로 작업이 멈춘 상태(stuck)라면 삭제가 진행될 수 있습니다.\n삭제할까요? (되돌릴 수 없습니다)'
+            : '이 영상을 삭제할까요? (되돌릴 수 없습니다)';
+
+        const ok = window.confirm(message);
         if (!ok) return;
 
         try {
@@ -56,6 +63,10 @@ function HomePage() {
             setVideos((prev) => (prev || []).filter((v) => v.id !== videoId));
             window.dispatchEvent(new Event('videos:changed'));
         } catch (err) {
+            if (err?.status === 409) {
+                setError('아직 처리 중인 영상은 삭제할 수 없습니다.');
+                return;
+            }
             setError(err?.message || 'Failed to delete video');
         }
     };

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ opencv-python-headless
 pydantic>=2.5.0
 python-dotenv
 requests
+pytest
 tenacity
 tqdm
 google-genai

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ supabase>=2.0.0
 boto3
 uvicorn[standard]
 langgraph
-boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ supabase>=2.0.0
 boto3
 uvicorn[standard]
 langgraph
+boto3

--- a/src/adk_chatbot/agent.py
+++ b/src/adk_chatbot/agent.py
@@ -31,11 +31,19 @@ def _process_api_base() -> str:
 def _call_process_api(method: str, path: str, payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
     url = f"{_process_api_base()}{path}"
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"}
+    internal_token = (
+        os.getenv("PROCESS_API_INTERNAL_TOKEN")
+        or os.getenv("INTERNAL_API_TOKEN")
+        or os.getenv("SUPABASE_KEY")
+    )
+    if internal_token:
+        headers["X-Internal-Token"] = internal_token
     req = urllib_request.Request(
         url,
         data=data,
         method=method.upper(),
-        headers={"Content-Type": "application/json"},
+        headers=headers,
     )
     try:
         with urllib_request.urlopen(req, timeout=5) as resp:

--- a/src/db/adapters/base.py
+++ b/src/db/adapters/base.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 # -----------------------------------------------------------------------------
 # Supabase Client Import
@@ -223,3 +223,57 @@ class BaseAdapter:
             str: ISO 8601 형식의 UTC 시간 (예: "2026-02-05T12:00:00+00:00")
         """
         return datetime.now(timezone.utc).isoformat()
+
+    # ---------------------------------------------------------------------
+    # Cloudflare R2 helpers
+    # ---------------------------------------------------------------------
+    def r2_delete_prefix(self, prefix: str) -> Dict[str, Any]:
+        """Delete every object under a given key prefix in the R2 bucket.
+
+        This is intentionally implemented as a prefix delete (list + batch delete)
+        so callers can reliably remove all artifacts for a video_id.
+
+        Returns:
+            Dict with keys:
+              - prefix: str
+              - total: int (objects found)
+              - deleted: int (objects deleted, best-effort)
+              - errors: list (delete_objects errors)
+        """
+        if not getattr(self, "s3_client", None):
+            if getattr(self, "r2_only", False):
+                raise RuntimeError("R2 storage is required (check R2_* env vars)")
+            return {"prefix": prefix, "total": 0, "deleted": 0, "errors": []}
+
+        bucket = getattr(self, "r2_bucket", None)
+        if not bucket:
+            raise RuntimeError("R2 bucket is not configured (check R2_BUCKET/R2_BUCKET_VIDEOS)")
+
+        keys: List[str] = []
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents") or []:
+                key = obj.get("Key")
+                if key:
+                    keys.append(key)
+
+        total = len(keys)
+        deleted = 0
+        errors: List[Dict[str, Any]] = []
+
+        # S3-compatible delete_objects supports up to 1000 objects per call.
+        for i in range(0, total, 1000):
+            chunk = keys[i : i + 1000]
+            objs = [{"Key": key} for key in chunk]
+            try:
+                resp = self.s3_client.delete_objects(Bucket=bucket, Delete={"Objects": objs})
+            except Exception as exc:
+                errors.append({"Key": prefix, "Code": "DeleteObjectsFailed", "Message": str(exc)})
+                continue
+
+            deleted_items = resp.get("Deleted") or []
+            resp_errors = resp.get("Errors") or []
+            deleted += len(deleted_items) if deleted_items else max(0, len(objs) - len(resp_errors))
+            errors.extend(resp_errors)
+
+        return {"prefix": prefix, "total": total, "deleted": deleted, "errors": errors}

--- a/src/process_api.py
+++ b/src/process_api.py
@@ -182,6 +182,7 @@ def _build_status_payload(adapter, video_id: str) -> Dict[str, Any]:
 
     result = {
         "video_id": video_id,
+        "video_name": video.get("name"),
         "video_status": video.get("status"),
         "error_message": video.get("error_message"),
     }

--- a/src/process_api.py
+++ b/src/process_api.py
@@ -50,11 +50,14 @@ import shutil
 import tempfile
 import threading
 import time
+import base64
+import hashlib
+import hmac
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import BackgroundTasks, FastAPI, HTTPException, UploadFile, File, Request
+from fastapi import BackgroundTasks, FastAPI, HTTPException, UploadFile, File, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pydantic import BaseModel
@@ -125,20 +128,32 @@ def get_last_run(video_name: str, output_base: str = "data/outputs") -> dict:
 
 
 @app.post("/process", response_model=ProcessResponse)
-def process_pipeline(request: ProcessRequest, background_tasks: BackgroundTasks) -> ProcessResponse:
+def process_pipeline(
+    request: ProcessRequest,
+    background_tasks: BackgroundTasks,
+    http_request: Request,
+) -> ProcessResponse:
     if not request.video_name and not request.video_id:
         raise HTTPException(status_code=400, detail="video_name or video_id is required.")
 
-    # 이미 PROCESSING 중이면 중복 실행 방지
+    # video_id 기반 요청만 인증/권한 체크 (video_name-only는 기존 dev/local 사용을 위해 허용)
     if request.video_id:
         adapter = get_supabase_adapter()
-        if adapter:
-            video = adapter.get_video(request.video_id)
-            if video and video.get("status") == "PROCESSING":
-                raise HTTPException(
-                    status_code=409,
-                    detail="Pipeline is already running for this video",
-                )
+        if not adapter:
+            raise HTTPException(status_code=503, detail="Database not configured")
+
+        if _is_internal_request(http_request):
+            video = _require_video_exists(adapter, request.video_id)
+        else:
+            user_id = _require_user_id(adapter, http_request)
+            video = _require_video_owner(adapter, user_id=user_id, video_id=request.video_id)
+
+        # 이미 PROCESSING 중이면 중복 실행 방지
+        if (video.get("status") or "").upper() == "PROCESSING":
+            raise HTTPException(
+                status_code=409,
+                detail="Pipeline is already running for this video",
+            )
 
     background_tasks.add_task(
         run_processing_pipeline,
@@ -236,11 +251,17 @@ def _build_summaries_payload(adapter, video_id: str) -> Dict[str, Any]:
 
 
 @app.get("/videos/{video_id}/status")
-def get_video_status(video_id: str) -> Dict[str, Any]:
+def get_video_status(video_id: str, http_request: Request) -> Dict[str, Any]:
     """비디오 상태 및 현재 작업 정보 조회."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
+
+    if _is_internal_request(http_request):
+        _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     result = _build_status_payload(adapter, video_id)
     if result is None:
@@ -250,7 +271,7 @@ def get_video_status(video_id: str) -> Dict[str, Any]:
 
 
 @app.get("/videos/{video_id}/status/stream")
-def stream_video_status(video_id: str):
+def stream_video_status(video_id: str, http_request: Request):
     """비디오 상태 및 요약을 SSE로 스트리밍합니다.
 
     이벤트 타입:
@@ -263,9 +284,11 @@ def stream_video_status(video_id: str):
         raise HTTPException(status_code=503, detail="Database not configured")
 
     # 초기 비디오 존재 확인
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    if _is_internal_request(http_request):
+        _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     def event_generator():
         last_status_json = None
@@ -317,16 +340,18 @@ def stream_video_status(video_id: str):
 
 
 @app.get("/videos/{video_id}/progress")
-def get_video_progress(video_id: str) -> Dict[str, Any]:
+def get_video_progress(video_id: str, http_request: Request) -> Dict[str, Any]:
     """처리 진행률 조회 (폴링용)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
     
     # 비디오 정보 조회
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    if _is_internal_request(http_request):
+        video = _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
     
     processing_job_id = video.get("current_processing_job_id")
     if not processing_job_id:
@@ -361,16 +386,18 @@ def get_video_progress(video_id: str) -> Dict[str, Any]:
 
 
 @app.get("/videos/{video_id}/summary")
-def get_video_summary(video_id: str, format: Optional[str] = None) -> Dict[str, Any]:
+def get_video_summary(video_id: str, http_request: Request, format: Optional[str] = None) -> Dict[str, Any]:
     """최신 요약 결과 조회 (IN_PROGRESS 포함)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
     
     # 비디오 존재 확인
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    if _is_internal_request(http_request):
+        video = _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
     
     # 최신 summary_results 조회
     summary_result = adapter.get_latest_summary_results(video_id, format)
@@ -408,15 +435,17 @@ def _parse_id_list(value: Optional[str]) -> List[str]:
 
 
 @app.get("/videos/{video_id}/summaries")
-def get_video_summaries(video_id: str) -> Dict[str, Any]:
+def get_video_summaries(video_id: str, http_request: Request) -> Dict[str, Any]:
     """세부 요약 세그먼트 리스트 조회 (Chatbot용)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    if _is_internal_request(http_request):
+        _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     return _build_summaries_payload(adapter, video_id)
 
@@ -424,6 +453,7 @@ def get_video_summaries(video_id: str) -> Dict[str, Any]:
 @app.get("/videos/{video_id}/evidence")
 def get_video_evidence(
     video_id: str,
+    http_request: Request,
     stt_ids: Optional[str] = None,
     cap_ids: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -432,9 +462,11 @@ def get_video_evidence(
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    if _is_internal_request(http_request):
+        _require_video_exists(adapter, video_id)
+    else:
+        user_id = _require_user_id(adapter, http_request)
+        _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     stt_list = _parse_id_list(stt_ids)
     cap_list = _parse_id_list(cap_ids)
@@ -565,7 +597,7 @@ async def upload_video(
         raise HTTPException(status_code=503, detail="Database not configured")
 
     video_name = Path(file.filename).stem
-    user_id = _get_user_id_from_request(adapter, http_request)
+    user_id = _require_user_id(adapter, http_request)
     video = adapter.create_video(
         name=video_name,
         original_filename=file.filename,
@@ -653,7 +685,7 @@ def init_upload(payload: UploadInitRequest, http_request: Request):
 
     video_name = Path(payload.filename).stem
     safe_name = _sanitize_filename(payload.filename)
-    user_id = _get_user_id_from_request(adapter, http_request)
+    user_id = _require_user_id(adapter, http_request)
     # 임시 ID 없이 레코드 먼저 생성하여 video_id 확보
     video = adapter.create_video(
         name=video_name,
@@ -719,15 +751,23 @@ class UploadCompleteResponse(BaseModel):
 def complete_upload(
     request: UploadCompleteRequest,
     background_tasks: BackgroundTasks,
+    http_request: Request,
 ):
     """Storage 업로드 완료 알림 → 파이프라인 실행."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    video = adapter.get_video(request.video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    user_id = _require_user_id(adapter, http_request)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=request.video_id)
+
+    # Safety: don't allow arbitrary keys outside the video's prefix.
+    if not request.storage_key.startswith(f"{request.video_id}/"):
+        raise HTTPException(status_code=400, detail="Invalid storage_key")
+
+    expected_storage_key = video.get("video_storage_key")
+    if expected_storage_key and expected_storage_key != request.storage_key:
+        raise HTTPException(status_code=400, detail="storage_key does not match the video")
 
     adapter.update_video_status(request.video_id, "PREPROCESSING")
 
@@ -877,26 +917,80 @@ def _run_async_pipeline_from_storage(video_id: str, storage_key: str) -> None:
 
 
 @app.get("/api/videos")
-def list_videos() -> Dict[str, Any]:
+def list_videos(http_request: Request) -> Dict[str, Any]:
     """비디오 목록 조회 (최신순)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    videos = adapter.list_videos()
+    user_id = _require_user_id(adapter, http_request)
+    videos = adapter.list_videos_for_user(user_id)
     return {"videos": videos}
 
 
+class MediaTicketResponse(BaseModel):
+    ticket: str
+    expires_in: int
+
+
+@app.post("/api/media/ticket", response_model=MediaTicketResponse)
+def issue_media_ticket(http_request: Request) -> MediaTicketResponse:
+    """Issue a short-lived, signed token for media endpoints (stream/thumbnail)."""
+    adapter = get_supabase_adapter()
+    if not adapter:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    user_id = _require_user_id(adapter, http_request)
+    ttl_sec = _MEDIA_TICKET_TTL_SEC
+    ticket = _create_media_ticket(user_id, ttl_sec=ttl_sec)
+    return MediaTicketResponse(ticket=ticket, expires_in=ttl_sec)
+
+
+@app.delete("/api/videos/{video_id}", status_code=204)
+def delete_video(video_id: str, http_request: Request) -> Response:
+    """Delete a user's video (DB rows + R2 objects under {video_id}/)."""
+    adapter = get_supabase_adapter()
+    if not adapter:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    user_id = _require_user_id(adapter, http_request)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
+
+    status = (video.get("status") or "").upper()
+    if status in ("PREPROCESSING", "PREPROCESS_DONE", "PROCESSING"):
+        raise HTTPException(status_code=409, detail="Video is still processing")
+
+    # Storage cleanup (R2) first so failures are retryable (DB row remains).
+    try:
+        r2_result = adapter.r2_delete_prefix(f"{video_id}/")
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Storage delete failed: {exc}")
+
+    errors = r2_result.get("errors") or []
+    if errors:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to delete storage objects ({len(errors)} errors)",
+        )
+
+    # DB delete (FK cascades will clean up children).
+    if not adapter.delete_video(video_id, user_id):
+        raise HTTPException(status_code=500, detail="Failed to delete video")
+
+    return Response(status_code=204)
+
+
 @app.get("/api/videos/{video_id}/stream")
-def stream_video(video_id: str):
+def stream_video(video_id: str, http_request: Request, ticket: Optional[str] = None):
     """비디오 파일 서빙 (Storage signed URL 또는 로컬 fallback)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    user_id = _require_user_id_from_request_or_ticket(adapter, http_request, ticket)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     # Storage에 업로드된 비디오가 있으면 signed URL로 리다이렉트
     storage_key = video.get("video_storage_key")
@@ -925,15 +1019,14 @@ def stream_video(video_id: str):
 
 
 @app.get("/api/videos/{video_id}/thumbnail")
-def get_video_thumbnail(video_id: str):
+def get_video_thumbnail(video_id: str, http_request: Request, ticket: Optional[str] = None):
     """비디오 썸네일 이미지 서빙 (captures 버킷 signed URL 또는 로컬 fallback)."""
     adapter = get_supabase_adapter()
     if not adapter:
         raise HTTPException(status_code=503, detail="Database not configured")
 
-    video = adapter.get_video(video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    user_id = _require_user_id_from_request_or_ticket(adapter, http_request, ticket)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
     # DB에서 첫 번째 캡처의 storage_path 조회
     try:
@@ -988,23 +1081,28 @@ def _resolve_video_name(video: Dict[str, Any], fallback: str) -> str:
     return fallback
 
 
-def _get_or_create_chat_session(request: ChatRequest):
+def _get_or_create_chat_session(
+    request: ChatRequest,
+    *,
+    video: Dict[str, Any],
+    user_id: str,
+):
     session = None
     if request.session_id:
         session = _chat_sessions.get(request.session_id)
+    if session:
+        # Safety: do not allow session reuse across different videos.
+        state = getattr(session, "_state", None)
+        if isinstance(state, dict):
+            session_video_id = state.get("video_id")
+            if session_video_id and str(session_video_id) != str(request.video_id):
+                session = None
+
     if session:
         # Update reasoning_mode if provided in request
         if request.reasoning_mode and request.reasoning_mode in ("flash", "thinking"):
             session._state["reasoning_mode"] = request.reasoning_mode
         return session
-
-    adapter = get_supabase_adapter()
-    if not adapter:
-        raise HTTPException(status_code=503, detail="Database not configured")
-
-    video = adapter.get_video(request.video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
 
     video_name = _resolve_video_name(video, request.video_id)
     initial_state = {
@@ -1021,6 +1119,7 @@ def _get_or_create_chat_session(request: ChatRequest):
         video_name,
         process_api_url="http://localhost:8080",
         initial_state=initial_state,
+        user_id=user_id,
     )
 
 
@@ -1063,10 +1162,123 @@ def _get_user_id_from_request(adapter, request: Request) -> Optional[str]:
     return None
 
 
+_MEDIA_TICKET_TTL_SEC = int(os.getenv("MEDIA_TICKET_TTL_SEC", "300"))
+
+
+def _media_ticket_secret() -> str:
+    # Prefer a dedicated secret, but fall back to SUPABASE_KEY (server-side secret) so
+    # local/dev setups still work without extra config.
+    return os.getenv("MEDIA_TICKET_SECRET") or os.getenv("SUPABASE_KEY") or ""
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padded = value + "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+
+def _create_media_ticket(user_id: str, *, ttl_sec: int = _MEDIA_TICKET_TTL_SEC) -> str:
+    if not user_id:
+        raise ValueError("user_id is required")
+    secret = _media_ticket_secret().encode("utf-8")
+    if not secret:
+        raise RuntimeError("MEDIA_TICKET_SECRET (or SUPABASE_KEY) is required")
+
+    exp = int(time.time()) + int(ttl_sec)
+    payload = {"uid": user_id, "exp": exp}
+    payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    payload_b64 = _b64url_encode(payload_json)
+    sig = hmac.new(secret, payload_b64.encode("ascii"), hashlib.sha256).digest()
+    sig_b64 = _b64url_encode(sig)
+    return f"{payload_b64}.{sig_b64}"
+
+
+def _verify_media_ticket(ticket: str) -> Optional[str]:
+    if not ticket:
+        return None
+    secret = _media_ticket_secret().encode("utf-8")
+    if not secret:
+        return None
+    try:
+        payload_b64, sig_b64 = ticket.split(".", 1)
+        expected_sig = hmac.new(secret, payload_b64.encode("ascii"), hashlib.sha256).digest()
+        expected_sig_b64 = _b64url_encode(expected_sig)
+        if not hmac.compare_digest(expected_sig_b64, sig_b64):
+            return None
+
+        payload = json.loads(_b64url_decode(payload_b64).decode("utf-8"))
+        exp = int(payload.get("exp") or 0)
+        if exp <= int(time.time()):
+            return None
+        uid = payload.get("uid")
+        return str(uid) if uid else None
+    except Exception:
+        return None
+
+
+def _require_user_id(adapter, request: Request) -> str:
+    user_id = _get_user_id_from_request(adapter, request)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return user_id
+
+
+def _require_user_id_from_request_or_ticket(adapter, request: Request, ticket: Optional[str]) -> str:
+    user_id = _get_user_id_from_request(adapter, request) or _verify_media_ticket(ticket or "")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return user_id
+
+
+def _require_video_owner(adapter, *, user_id: str, video_id: str) -> Dict[str, Any]:
+    video = adapter.get_video(video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+    if str(video.get("user_id") or "") != str(user_id):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return video
+
+
+def _internal_api_token() -> str:
+    # Used for server-to-server calls (e.g. chatbot code calling back into this API).
+    return (
+        os.getenv("PROCESS_API_INTERNAL_TOKEN")
+        or os.getenv("INTERNAL_API_TOKEN")
+        or os.getenv("SUPABASE_KEY")
+        or ""
+    )
+
+
+def _is_internal_request(request: Request) -> bool:
+    expected = _internal_api_token()
+    if not expected:
+        return False
+    token = request.headers.get("x-internal-token") or request.headers.get("X-Internal-Token") or ""
+    if not token:
+        return False
+    return hmac.compare_digest(token, expected)
+
+
+def _require_video_exists(adapter, video_id: str) -> Dict[str, Any]:
+    video = adapter.get_video(video_id)
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+    return video
+
+
 @app.post("/api/chat", response_model=ChatResponse)
-def chat(request: ChatRequest) -> ChatResponse:
+def chat(request: ChatRequest, http_request: Request) -> ChatResponse:
     """LangGraph 기반 챗봇 API (비스트리밍)."""
-    session = _get_or_create_chat_session(request)
+    adapter = get_supabase_adapter()
+    if not adapter:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    user_id = _require_user_id(adapter, http_request)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=request.video_id)
+    session = _get_or_create_chat_session(request, video=video, user_id=user_id)
     messages = session.send_message(request.message)
     response_text = "".join([getattr(msg, "text", "") for msg in messages if msg])
     return ChatResponse(
@@ -1076,9 +1288,15 @@ def chat(request: ChatRequest) -> ChatResponse:
 
 
 @app.post("/api/chat/stream")
-def chat_stream(request: ChatRequest):
+def chat_stream(request: ChatRequest, http_request: Request):
     """LangGraph 기반 챗봇 API (SSE 스트리밍)."""
-    session = _get_or_create_chat_session(request)
+    adapter = get_supabase_adapter()
+    if not adapter:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    user_id = _require_user_id(adapter, http_request)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=request.video_id)
+    session = _get_or_create_chat_session(request, video=video, user_id=user_id)
 
     def event_generator():
         yield _format_sse_event("session", {"session_id": session.session_id})
@@ -1148,7 +1366,7 @@ class STTProcessResponse(BaseModel):
 
 
 @app.post("/stt/process", response_model=STTProcessResponse)
-def process_stt_from_storage(request: STTProcessRequest) -> STTProcessResponse:
+def process_stt_from_storage(request: STTProcessRequest, http_request: Request) -> STTProcessResponse:
     """Storage에서 오디오를 다운받아 STT를 처리하고 결과를 DB에 저장한다.
     
     사용 예시:
@@ -1163,9 +1381,8 @@ def process_stt_from_storage(request: STTProcessRequest) -> STTProcessResponse:
         raise HTTPException(status_code=503, detail="Database not configured")
     
     # 비디오 존재 확인
-    video = adapter.get_video(request.video_id)
-    if not video:
-        raise HTTPException(status_code=404, detail="Video not found")
+    user_id = _require_user_id(adapter, http_request)
+    video = _require_video_owner(adapter, user_id=user_id, video_id=request.video_id)
     
     try:
         # 1. Storage에서 오디오 다운로드 → STT 실행

--- a/src/services/summary_backend.py
+++ b/src/services/summary_backend.py
@@ -351,11 +351,19 @@ class ProcessApiBackend:
     ) -> Dict[str, Any]:
         url = f"{self._base_url}{path}"
         data = json.dumps(payload).encode("utf-8") if payload is not None else None
+        headers = {"Content-Type": "application/json"}
+        internal_token = (
+            os.getenv("PROCESS_API_INTERNAL_TOKEN")
+            or os.getenv("INTERNAL_API_TOKEN")
+            or os.getenv("SUPABASE_KEY")
+        )
+        if internal_token:
+            headers["X-Internal-Token"] = internal_token
         req = urllib_request.Request(
             url,
             data=data,
             method=method.upper(),
-            headers={"Content-Type": "application/json"},
+            headers=headers,
         )
         try:
             with urllib_request.urlopen(req, timeout=5) as resp:

--- a/tests/test_media_ticket.py
+++ b/tests/test_media_ticket.py
@@ -1,0 +1,33 @@
+import src.process_api as process_api
+
+
+def test_media_ticket_roundtrip(monkeypatch):
+    monkeypatch.setenv("MEDIA_TICKET_SECRET", "test-secret")
+    monkeypatch.setattr(process_api.time, "time", lambda: 1_000)
+
+    ticket = process_api._create_media_ticket("user-123", ttl_sec=60)
+    assert process_api._verify_media_ticket(ticket) == "user-123"
+
+
+def test_media_ticket_expired(monkeypatch):
+    monkeypatch.setenv("MEDIA_TICKET_SECRET", "test-secret")
+    monkeypatch.setattr(process_api.time, "time", lambda: 1_000)
+
+    ticket = process_api._create_media_ticket("user-123", ttl_sec=10)
+
+    monkeypatch.setattr(process_api.time, "time", lambda: 1_011)
+    assert process_api._verify_media_ticket(ticket) is None
+
+
+def test_media_ticket_tamper_rejected(monkeypatch):
+    monkeypatch.setenv("MEDIA_TICKET_SECRET", "test-secret")
+    monkeypatch.setattr(process_api.time, "time", lambda: 1_000)
+
+    ticket = process_api._create_media_ticket("user-123", ttl_sec=60)
+    payload_b64, sig_b64 = ticket.split(".", 1)
+
+    # Flip a bit in the signature.
+    tampered_sig = sig_b64[:-1] + ("A" if sig_b64[-1] != "A" else "B")
+    tampered = f"{payload_b64}.{tampered_sig}"
+    assert process_api._verify_media_ticket(tampered) is None
+

--- a/tests/test_storage_delete_fallback.py
+++ b/tests/test_storage_delete_fallback.py
@@ -1,0 +1,155 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.process_api as process_api
+
+
+class FakeStorageBucket:
+    def __init__(self, bucket: str, recorder, *, should_fail: bool = False) -> None:
+        self.bucket = bucket
+        self.recorder = recorder
+        self.should_fail = should_fail
+
+    def remove(self, paths):
+        if self.should_fail:
+            raise RuntimeError(f"remove failed for bucket={self.bucket}")
+        self.recorder.append((self.bucket, list(paths)))
+        return {"data": [{"name": p} for p in paths]}
+
+
+class FakeStorage:
+    def __init__(self, recorder, *, fail_buckets=None) -> None:
+        self.recorder = recorder
+        self.fail_buckets = set(fail_buckets or [])
+
+    def from_(self, bucket: str):
+        return FakeStorageBucket(bucket, self.recorder, should_fail=bucket in self.fail_buckets)
+
+
+class FakeTableQuery:
+    def __init__(self, table: str, data_by_table: dict, *, video_id: str) -> None:
+        self.table = table
+        self.data_by_table = data_by_table
+        self.video_id = video_id
+        self._eq = {}
+
+    def select(self, _fields: str):
+        return self
+
+    def eq(self, col: str, value: str):
+        self._eq[col] = value
+        return self
+
+    def execute(self):
+        if self._eq.get("video_id") != self.video_id:
+            return SimpleNamespace(data=[])
+        return SimpleNamespace(data=self.data_by_table.get(self.table, []))
+
+
+class FakeClient:
+    def __init__(self, recorder, data_by_table: dict, *, video_id: str, fail_buckets=None) -> None:
+        self.storage = FakeStorage(recorder, fail_buckets=fail_buckets)
+        self._data_by_table = data_by_table
+        self._video_id = video_id
+
+    def table(self, name: str):
+        return FakeTableQuery(name, self._data_by_table, video_id=self._video_id)
+
+
+class FakeAdapter:
+    def __init__(self, video_id: str, *, fail_buckets=None, r2_only: bool = False) -> None:
+        self.s3_client = None
+        self.r2_only = r2_only
+        self.deleted_videos = []
+        self.removed = []
+        self.videos = {
+            video_id: {
+                "id": video_id,
+                "user_id": "owner",
+                "video_storage_key": f"{video_id}/video.mp4",
+            }
+        }
+
+        data_by_table = {
+            "captures": [
+                {"storage_path": f"{video_id}/cap_001.jpg"},
+                {"storage_path": "other/ignore.jpg"},
+            ],
+            "preprocessing_jobs": [{"audio_storage_key": f"{video_id}/audio.wav"}],
+        }
+        self.client = FakeClient(self.removed, data_by_table, video_id=video_id, fail_buckets=fail_buckets)
+
+    def get_video(self, video_id: str):
+        return self.videos.get(video_id)
+
+    def delete_video(self, video_id: str, user_id: str) -> bool:
+        self.deleted_videos.append((video_id, user_id))
+        return True
+
+    # Methods referenced by _is_video_actively_processing (not used in these tests).
+    def get_preprocessing_job(self, _job_id: str):
+        return None
+
+    def get_processing_job(self, _job_id: str):
+        return None
+
+
+@pytest.fixture
+def client_and_adapter(monkeypatch):
+    video_id = "v1"
+    adapter = FakeAdapter(video_id)
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+
+    def fake_get_user_id(_adapter, request):
+        auth = request.headers.get("Authorization") or ""
+        if auth.lower().startswith("bearer "):
+            return auth.split(" ", 1)[1].strip()
+        return None
+
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", fake_get_user_id)
+    return TestClient(process_api.app), adapter, video_id
+
+
+def test_delete_video_supabase_storage_fallback_ok(client_and_adapter):
+    http, adapter, video_id = client_and_adapter
+    res = http.delete(f"/api/videos/{video_id}", headers={"Authorization": "Bearer owner"})
+
+    assert res.status_code == 204
+    assert adapter.deleted_videos == [(video_id, "owner")]
+
+    # remove() should be called per bucket with known paths.
+    assert ("videos", [f"{video_id}/video.mp4"]) in adapter.removed
+    assert ("captures", [f"{video_id}/cap_001.jpg"]) in adapter.removed
+    assert ("audio", [f"{video_id}/audio.wav"]) in adapter.removed
+
+
+def test_delete_video_supabase_storage_fallback_failure_blocks_db_delete(monkeypatch):
+    video_id = "v1"
+    adapter = FakeAdapter(video_id, fail_buckets={"captures"})
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", lambda _adapter, _request: "owner")
+
+    http = TestClient(process_api.app)
+    res = http.delete(f"/api/videos/{video_id}", headers={"Authorization": "Bearer owner"})
+
+    assert res.status_code == 502
+    assert adapter.deleted_videos == []
+
+
+def test_delete_video_requires_r2_when_flagged(monkeypatch):
+    video_id = "v1"
+    adapter = FakeAdapter(video_id, r2_only=True)
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", lambda _adapter, _request: "owner")
+
+    http = TestClient(process_api.app)
+    res = http.delete(f"/api/videos/{video_id}", headers={"Authorization": "Bearer owner"})
+
+    assert res.status_code == 503
+    assert adapter.deleted_videos == []
+

--- a/tests/test_video_delete_auth.py
+++ b/tests/test_video_delete_auth.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.process_api as process_api
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.s3_client = object()
+        self.r2_only = True
+        self.videos = {}
+        self.preprocessing_jobs = {}
+        self.processing_jobs = {}
+        self.deleted_prefixes = []
+        self.deleted_videos = []
+
+    def get_video(self, video_id: str):
+        return self.videos.get(video_id)
+
+    def delete_video(self, video_id: str, user_id: str) -> bool:
+        self.deleted_videos.append((video_id, user_id))
+        return True
+
+    def r2_delete_prefix(self, prefix: str):
+        self.deleted_prefixes.append(prefix)
+        return {"prefix": prefix, "total": 1, "deleted": 1, "errors": []}
+
+    def get_preprocessing_job(self, job_id: str):
+        return self.preprocessing_jobs.get(job_id)
+
+    def get_processing_job(self, job_id: str):
+        return self.processing_jobs.get(job_id)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    adapter = FakeAdapter()
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+
+    def fake_get_user_id(_adapter, request):
+        auth = request.headers.get("Authorization") or request.headers.get("authorization") or ""
+        if auth.lower().startswith("bearer "):
+            return auth.split(" ", 1)[1].strip()
+        return None
+
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", fake_get_user_id)
+    return TestClient(process_api.app), adapter
+
+
+def test_delete_video_requires_owner(client):
+    http, adapter = client
+    adapter.videos["v1"] = {"id": "v1", "user_id": "owner"}
+
+    res = http.delete("/api/videos/v1", headers={"Authorization": "Bearer other"})
+    assert res.status_code == 403
+    assert adapter.deleted_videos == []
+
+
+def test_delete_video_owner_ok(client):
+    http, adapter = client
+    adapter.videos["v1"] = {"id": "v1", "user_id": "owner"}
+
+    res = http.delete("/api/videos/v1", headers={"Authorization": "Bearer owner"})
+    assert res.status_code == 204
+    assert adapter.deleted_prefixes == ["v1/"]
+    assert adapter.deleted_videos == [("v1", "owner")]
+
+
+def test_delete_video_blocks_while_job_active(client):
+    http, adapter = client
+    adapter.videos["v1"] = {
+        "id": "v1",
+        "user_id": "owner",
+        "current_processing_job_id": "job1",
+    }
+    adapter.processing_jobs["job1"] = {
+        "id": "job1",
+        "status": "VLM_RUNNING",
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    res = http.delete("/api/videos/v1", headers={"Authorization": "Bearer owner"})
+    assert res.status_code == 409
+    assert adapter.deleted_videos == []
+
+
+def test_delete_video_allows_stuck_job(client):
+    http, adapter = client
+    adapter.videos["v1"] = {
+        "id": "v1",
+        "user_id": "owner",
+        "current_processing_job_id": "job1",
+    }
+    adapter.processing_jobs["job1"] = {
+        "id": "job1",
+        "status": "VLM_RUNNING",
+        "updated_at": "2000-01-01T00:00:00+00:00",
+    }
+
+    res = http.delete("/api/videos/v1", headers={"Authorization": "Bearer owner"})
+    assert res.status_code == 204
+    assert adapter.deleted_videos == [("v1", "owner")]
+


### PR DESCRIPTION
## 배경
- Storage가 `Supabase Storage` → `Cloudflare R2`로 전환되어, **동영상 삭제 시 DB + Storage(R2) 정리**가 함께 필요합니다.
- `feat`에서 진행된 **비동기 처리 API / UI 개선 흐름**이 깨지지 않도록 최신 `feat` 위로 리베이스하여 통합했습니다.

## 변경 사항
### 1) 동영상 삭제 (DB + R2)
- `DELETE /api/videos/{video_id}` 추가
- 동작:
  - 요청자 소유권 확인
  - R2에서 `{video_id}/` prefix 하위 오브젝트 전체 삭제(list + batch delete)
  - `videos` row 삭제 (FK `ON DELETE CASCADE`로 하위 테이블 정리)
- 처리중 상태(`PREPROCESSING|PREPROCESS_DONE|PROCESSING`)는 삭제 차단(HTTP 409)

### 2) 권한 강화 (서버에서 강제)
- 프론트에서 "내 영상만" 보여줘도 **API 직접 호출로 남의 video_id 접근 시도가 가능**하므로,
  `video_id` 기반 주요 엔드포인트들에서 **소유권 체크**를 서버에서 수행하도록 보강했습니다.
- 내부 서버→서버 호출은 `X-Internal-Token`으로 우회 가능하도록 처리했습니다.

### 3) 미디어 접근(ticket)
- `<video src>` / `<img src>`는 Authorization 헤더를 보낼 수 없어서,
  `POST /api/media/ticket`으로 짧은 TTL의 HMAC ticket을 발급하고
  `/api/videos/{video_id}/stream`, `/api/videos/{video_id}/thumbnail`에 `?ticket=...`로 접근하도록 처리했습니다.

### 4) 프론트 UX
- 홈 카드에 삭제 버튼 추가 및 삭제 후 리스트 즉시 갱신
- 썸네일/스트림 URL에 ticket 적용
- SSE status stream / 채팅 stream 요청에 Authorization 헤더 적용

## feat 회귀 방지
- 최신 `feat` 기준으로 리베이스하여 비동기 API/UI 개선 변경사항을 포함합니다.
- `/process`는 기존 `feat`의 **중복 실행 방지(이미 PROCESSING이면 409)** 로직을 유지하면서,
  `video_id` 기반 요청에만 소유권 체크를 추가했습니다.

## 테스트
- Python: `python -m py_compile ...`
- Frontend: `npm run build`
- [x] 업로드/처리 진행(SSE) 체크
- [x] 완료 영상 삭제(204) 및 DB / R2 Storage 갱신 체크
- [x] 처리중 영상 삭제 차단(409) 체크