### PR TITLE
fix: 요약 재시작/상태 동기화 + rerun DB 업로드 보장

### DIFF
--- a/frontend/src/api/videos.js
+++ b/frontend/src/api/videos.js
@@ -98,7 +98,8 @@ export function getVideoProgress(videoId) {
 }
 
 export function restartProcessing(videoId) {
-  return post('/process', { video_id: videoId });
+  // Ensure reruns publish results back into DB so the UI can read summaries.
+  return post('/process', { video_id: videoId, sync_to_db: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/VideoCard.jsx
+++ b/frontend/src/components/VideoCard.jsx
@@ -11,6 +11,7 @@ function VideoCard({ id, title, thumbnail, thumbnailVideoId, duration, date, sta
 
     const statusConfig = {
         done: { label: '완료', color: '#22c55e' },
+        failed: { label: '요약 실패', color: '#ef4444' },
         progress: { label: '분석 중', color: '#f59e0b' },
         pending: { label: '대기', color: '#6b7280' },
     };

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -12,7 +12,7 @@ function mapStatus(dbStatus) {
     if (!dbStatus) return 'pending';
     const s = dbStatus.toUpperCase();
     if (s === 'DONE') return 'done';
-    if (s === 'FAILED') return 'done';
+    if (s === 'FAILED') return 'failed';
     if (['PREPROCESSING', 'PREPROCESS_DONE', 'PROCESSING', 'VLM_RUNNING', 'SUMMARY_RUNNING', 'JUDGE_RUNNING'].includes(s))
         return 'progress';
     return 'pending';
@@ -78,7 +78,7 @@ function HomePage() {
     const filtered = videos.filter((v) => {
         if (filter === 'all') return true;
         const uiStatus = mapStatus(v.status);
-        if (filter === 'done') return uiStatus === 'done';
+        if (filter === 'done') return uiStatus === 'done' || uiStatus === 'failed';
         if (filter === 'progress') return uiStatus === 'progress' || uiStatus === 'pending';
         return true;
     });

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+
+# Ensure `import src...` works under pytest importlib mode by putting the repo root
+# on sys.path.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_process_restart_status.py
+++ b/tests/test_process_restart_status.py
@@ -1,0 +1,72 @@
+from fastapi.testclient import TestClient
+
+import src.process_api as process_api
+
+
+class FakeAdapter:
+    def __init__(self) -> None:
+        self.videos = {
+            "v1": {
+                "id": "v1",
+                "user_id": "owner",
+                "status": "FAILED",
+                "error_message": "boom",
+            }
+        }
+        self.update_calls = []
+
+    def get_video(self, video_id: str):
+        return self.videos.get(video_id)
+
+    def update_video_status(self, video_id: str, status: str, error=None):
+        # Simulate DB behavior expected by the API layer.
+        self.update_calls.append((video_id, status, error))
+        row = self.videos[video_id]
+        row["status"] = status
+        if (status or "").upper() == "FAILED":
+            if error is not None:
+                row["error_message"] = error
+        else:
+            row["error_message"] = None
+        return row
+
+
+def test_process_restart_marks_processing_and_clears_error(monkeypatch):
+    adapter = FakeAdapter()
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+
+    def fake_get_user_id(_adapter, request):
+        auth = request.headers.get("Authorization") or ""
+        if auth.lower().startswith("bearer "):
+            return auth.split(" ", 1)[1].strip()
+        return None
+
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", fake_get_user_id)
+
+    pipeline_calls = []
+    monkeypatch.setattr(process_api, "run_processing_pipeline", lambda **kwargs: pipeline_calls.append(kwargs))
+
+    http = TestClient(process_api.app)
+    res = http.post("/process", json={"video_id": "v1"}, headers={"Authorization": "Bearer owner"})
+
+    assert res.status_code == 200
+    assert adapter.videos["v1"]["status"] == "PROCESSING"
+    assert adapter.videos["v1"]["error_message"] is None
+    assert pipeline_calls and pipeline_calls[0]["video_id"] == "v1"
+    assert pipeline_calls[0]["sync_to_db"] is True
+
+
+def test_process_blocks_duplicate_run(monkeypatch):
+    adapter = FakeAdapter()
+
+    monkeypatch.setattr(process_api, "get_supabase_adapter", lambda: adapter)
+    monkeypatch.setattr(process_api, "_get_user_id_from_request", lambda _adapter, _request: "owner")
+    monkeypatch.setattr(process_api, "run_processing_pipeline", lambda **_kwargs: None)
+
+    http = TestClient(process_api.app)
+    first = http.post("/process", json={"video_id": "v1"}, headers={"Authorization": "Bearer owner"})
+    assert first.status_code == 200
+
+    second = http.post("/process", json={"video_id": "v1"}, headers={"Authorization": "Bearer owner"})
+    assert second.status_code == 409

--- a/tests/test_processing_job_sync.py
+++ b/tests/test_processing_job_sync.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+from src.db.adapters.job_adapter import JobAdapterMixin
+
+
+class FakeTableQuery:
+    def __init__(self, name: str, client) -> None:
+        self.name = name
+        self.client = client
+        self._op = None
+        self._payload = None
+        self._eq = {}
+
+    def update(self, payload):
+        self._op = "update"
+        self._payload = payload
+        return self
+
+    def select(self, _fields: str):
+        self._op = "select"
+        return self
+
+    def eq(self, col: str, value: str):
+        self._eq[col] = value
+        return self
+
+    def execute(self):
+        if self.name != "processing_jobs":
+            raise AssertionError(f"unexpected table: {self.name}")
+
+        job_id = self._eq.get("id")
+        video_id = self.client.video_id_by_job_id.get(job_id)
+
+        if self._op == "update":
+            self.client.processing_job_updates.append((job_id, dict(self._payload or {})))
+            row = {"id": job_id, "video_id": video_id}
+            return SimpleNamespace(data=[row])
+
+        if self._op == "select":
+            if not video_id:
+                return SimpleNamespace(data=[])
+            return SimpleNamespace(data=[{"video_id": video_id}])
+
+        raise AssertionError(f"unexpected op: {self._op}")
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.video_id_by_job_id = {"job1": "v1"}
+        self.processing_job_updates = []
+
+    def table(self, name: str):
+        return FakeTableQuery(name, self)
+
+
+class FakeAdapter(JobAdapterMixin):
+    def __init__(self, client) -> None:
+        self.client = client
+        self.video_status_updates = []
+
+    def update_video_status(self, video_id: str, status: str, error=None):
+        self.video_status_updates.append((video_id, status, error))
+        return {"id": video_id, "status": status}
+
+
+def test_processing_job_done_syncs_video_status():
+    client = FakeClient()
+    adapter = FakeAdapter(client)
+
+    adapter.update_processing_job_status("job1", "DONE")
+    assert adapter.video_status_updates == [("v1", "DONE", None)]
+
+
+def test_processing_job_failed_syncs_video_status():
+    client = FakeClient()
+    adapter = FakeAdapter(client)
+
+    adapter.update_processing_job_status("job1", "FAILED", error_message="boom")
+    assert adapter.video_status_updates == [("v1", "FAILED", "boom")]
+
+
+def test_processing_job_non_terminal_does_not_sync_video_status():
+    client = FakeClient()
+    adapter = FakeAdapter(client)
+
+    adapter.update_processing_job_status("job1", "VLM_RUNNING")
+    assert adapter.video_status_updates == []
+

--- a/tests/test_video_status_update_payload.py
+++ b/tests/test_video_status_update_payload.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+from src.db.adapters.video_adapter import VideoAdapterMixin
+
+
+class FakeTableQuery:
+    def __init__(self, name: str, recorder) -> None:
+        self.name = name
+        self.recorder = recorder
+        self._payload = None
+        self._eq = {}
+
+    def update(self, payload):
+        self._payload = dict(payload)
+        return self
+
+    def eq(self, col: str, value: str):
+        self._eq[col] = value
+        return self
+
+    def execute(self):
+        assert self.name == "videos"
+        self.recorder.append((dict(self._payload or {}), dict(self._eq)))
+        video_id = self._eq.get("id")
+        return SimpleNamespace(data=[{"id": video_id, **(self._payload or {})}])
+
+
+class FakeClient:
+    def __init__(self, recorder) -> None:
+        self.recorder = recorder
+
+    def table(self, name: str):
+        return FakeTableQuery(name, self.recorder)
+
+
+class FakeAdapter(VideoAdapterMixin):
+    def __init__(self, client) -> None:
+        self.client = client
+
+
+def test_update_video_status_clears_error_message_on_non_failed():
+    updates = []
+    adapter = FakeAdapter(FakeClient(updates))
+
+    adapter.update_video_status("v1", "PROCESSING")
+    payload, where = updates[-1]
+    assert where == {"id": "v1"}
+    assert payload["status"] == "PROCESSING"
+    assert payload["error_message"] is None
+
+
+def test_update_video_status_sets_error_message_on_failed_when_provided():
+    updates = []
+    adapter = FakeAdapter(FakeClient(updates))
+
+    adapter.update_video_status("v1", "FAILED", error="boom")
+    payload, _where = updates[-1]
+    assert payload["status"] == "FAILED"
+    assert payload["error_message"] == "boom"
+
+
+def test_update_video_status_does_not_overwrite_error_message_on_failed_without_error():
+    updates = []
+    adapter = FakeAdapter(FakeClient(updates))
+
+    adapter.update_video_status("v1", "FAILED", error=None)
+    payload, _where = updates[-1]
+    assert payload["status"] == "FAILED"
+    assert "error_message" not in payload
+


### PR DESCRIPTION
## 문제
- 요약 재시작을 눌러도 실패 배너(error_message)가 남아있거나, 완료 후에도 진행중으로 남는 현상
- 요약 실패인데 라이브러리 카드가 완료로 표시되는 현상
- 이전에 실패했던 video를 다시 돌릴 때 파이프라인은 돌아가지만 DB로 summaries가 업로드되지 않아 프론트에서 읽지 못하는 현상

## 변경 사항
### 백엔드
- `/process`(video_id 기반) 호출 시 즉시 `videos.status=PROCESSING`으로 전환 + `error_message` 초기화
- `/process`(video_id 기반)에서 `sync_to_db` 미지정 시 기본값을 `True`로 강제하여 rerun 시 DB 업로드 보장
- `processing_jobs.status`가 `DONE/FAILED`로 끝나면 `videos.status`도 `DONE/FAILED`로 동기화 (SSE done 이벤트/종료 조건 안정화)
- `update_video_status`는 `FAILED`를 벗어나는 상태 전환에서 `error_message`를 항상 클리어하도록 통일
- `create_processing_job`에서 `videos.error_message`도 함께 클리어

### 프론트엔드
- 라이브러리 상태 매핑 수정: `FAILED`를 완료가 아닌 `failed`로 분리하고 카드 배지는 `요약 실패`로 표시
- Analysis 헤더 status 라벨을 SSE로 실시간 갱신
- 요약 재시작 요청(`/process`)에 `sync_to_db: true`를 명시적으로 포함

## 테스트
- `pytest -q` 통과
- `npm run build`(frontend) 통과

## 참고 파일
- 백엔드: `src/process_api.py`, `src/db/adapters/video_adapter.py`, `src/db/adapters/job_adapter.py`
- 프론트: `frontend/src/api/videos.js`, `frontend/src/pages/HomePage.jsx`, `frontend/src/components/VideoCard.jsx`, `frontend/src/pages/AnalysisPage.jsx`
- 테스트: `tests/*`