### PR TITLE
feat: 처리 중 영상 삭제 허용 및 파이프라인 취소 처리

### DIFF
--- a/frontend/src/hooks/useVideoStatusStream.js
+++ b/frontend/src/hooks/useVideoStatusStream.js
@@ -124,6 +124,16 @@ export default function useVideoStatusStream(
       });
 
       if (!res.ok) {
+        // If the video was deleted, stop retrying and let the caller decide how to react.
+        if (res.status === 404) {
+          const err = new Error('Video not found');
+          err.status = 404;
+          stoppedRef.current = true;
+          setIsConnected(false);
+          setError(err);
+          if (onErrorRef.current) onErrorRef.current(err);
+          return;
+        }
         throw new Error(`HTTP ${res.status}: ${res.statusText}`);
       }
 

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -61,11 +61,7 @@ function HomePage() {
             setVideos((prev) => (prev || []).filter((v) => v.id !== deleteTarget.id));
             window.dispatchEvent(new Event('videos:changed'));
         } catch (err) {
-            if (err?.status === 409) {
-                setError('아직 처리 중인 영상은 삭제할 수 없습니다.');
-            } else {
-                setError(err?.message || 'Failed to delete video');
-            }
+            setError(err?.message || 'Failed to delete video');
         } finally {
             setDeleteTarget(null);
         }

--- a/src/db/supabase_schema.sql
+++ b/src/db/supabase_schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS videos (
     current_summary_result_id UUID,  -- FK added after summary_results created
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
+    delete_requested_at TIMESTAMPTZ,
     
     CONSTRAINT check_video_status CHECK (status IN ('UPLOADED', 'PREPROCESSING', 'PREPROCESS_DONE', 'PROCESSING', 'DONE', 'FAILED'))
 );
@@ -398,6 +399,11 @@ BEGIN
     ALTER TABLE videos DROP CONSTRAINT IF EXISTS check_video_status;
     ALTER TABLE videos ADD CONSTRAINT check_video_status
         CHECK (status IN ('UPLOADED', 'PREPROCESSING', 'PREPROCESS_DONE', 'PROCESSING', 'DONE', 'FAILED'));
+
+    -- videos.delete_requested_at 컬럼 추가 (처리 중 삭제/취소 신호용)
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'videos' AND column_name = 'delete_requested_at') THEN
+        ALTER TABLE videos ADD COLUMN delete_requested_at TIMESTAMPTZ;
+    END IF;
 
     -- stt_results.stt_id 컬럼 추가
     IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'stt_results' AND column_name = 'stt_id') THEN

--- a/src/pipeline/cancel.py
+++ b/src/pipeline/cancel.py
@@ -1,0 +1,97 @@
+"""Pipeline cancellation helpers.
+
+We support two cancellation signals:
+1) In-memory (same-process): fast signal for FastAPI BackgroundTasks.
+2) DB marker (cross-instance): videos.delete_requested_at set.
+
+The DB marker is the source of truth for Cloud Run / multi-worker deployments.
+The in-memory marker is best-effort to stop work quickly inside a single process.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+class PipelineCanceled(RuntimeError):
+    """Raised when a running pipeline should stop early (video deleted or delete requested)."""
+
+
+@dataclass(frozen=True)
+class CancelCheckResult:
+    canceled: bool
+    reason: Optional[str] = None
+
+
+_LOCAL_CANCELLED_VIDEO_IDS: set[str] = set()
+
+
+def request_local_cancel(video_id: str) -> None:
+    if video_id:
+        _LOCAL_CANCELLED_VIDEO_IDS.add(str(video_id))
+
+
+def clear_local_cancel(video_id: str) -> None:
+    if video_id:
+        _LOCAL_CANCELLED_VIDEO_IDS.discard(str(video_id))
+
+
+def is_local_cancel_requested(video_id: str) -> bool:
+    return bool(video_id) and str(video_id) in _LOCAL_CANCELLED_VIDEO_IDS
+
+
+def _coerce_dt(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    raw = str(value).strip()
+    if not raw:
+        return None
+    raw = raw.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def check_cancel_requested(adapter: Any, video_id: Optional[str]) -> CancelCheckResult:
+    """Return cancellation decision for a video_id.
+
+    - If local cancel is requested: cancel.
+    - If adapter is provided, treat missing video row as cancel.
+    - If videos.delete_requested_at is set: cancel.
+    """
+    if not video_id:
+        return CancelCheckResult(False, None)
+
+    if is_local_cancel_requested(video_id):
+        return CancelCheckResult(True, "local_cancel")
+
+    if not adapter:
+        return CancelCheckResult(False, None)
+
+    try:
+        video = adapter.get_video(video_id)
+    except Exception:
+        # If we can't check, don't assume cancel.
+        return CancelCheckResult(False, None)
+
+    if not video:
+        return CancelCheckResult(True, "video_deleted")
+
+    dt = _coerce_dt(video.get("delete_requested_at"))
+    if dt is not None:
+        return CancelCheckResult(True, "delete_requested")
+
+    return CancelCheckResult(False, None)
+
+
+def raise_if_cancel_requested(adapter: Any, video_id: Optional[str]) -> None:
+    decision = check_cancel_requested(adapter, video_id)
+    if decision.canceled:
+        raise PipelineCanceled(decision.reason or "canceled")
+

--- a/src/run_preprocess_pipeline.py
+++ b/src/run_preprocess_pipeline.py
@@ -58,6 +58,7 @@ from src.db.pipeline_sync import (
 )
 from src.db.adapters import compute_config_hash
 from src.pipeline.benchmark import BenchmarkTimer, format_duration, get_video_info, print_benchmark_report
+from src.pipeline.cancel import PipelineCanceled, is_local_cancel_requested, raise_if_cancel_requested
 from src.pipeline.logger import pipeline_logger
 from src.pipeline.stages import run_capture, run_stt, run_stt_only, run_stt_from_storage
 from src.audio.extract_audio import extract_audio
@@ -248,6 +249,14 @@ def run_preprocess_pipeline(
         captures_dir = video_root / "captures"
         manifest_json = video_root / "manifest.json"
 
+        # Early cancel (e.g., user deleted the video while a BackgroundTask is running).
+        if db_context:
+            adapter, video_id, _preprocess_job_id = db_context
+            raise_if_cancel_requested(adapter, video_id)
+        else:
+            # No DB context: still honor same-process cancellation.
+            raise_if_cancel_requested(None, existing_video_id)
+
         print(f"\nStarting preprocessing (parallel={parallel})...")
         print("-" * 50)
 
@@ -271,7 +280,10 @@ def run_preprocess_pipeline(
             if db_context:
                 db_start = time.perf_counter()
                 adapter, video_id, preprocess_job_id = db_context
-                
+
+                # Don't upload artifacts after delete is requested.
+                raise_if_cancel_requested(adapter, video_id)
+                 
                 # [Fix] Capture 중복 업로드 방지
                 # 스트리밍으로 이미 업로드된 경우(skip_db_capture=True), 배치 업로드는 수행하지 않음
                 do_capture_sync = (stage == "capture" and not kwargs.get("skip_db_capture", False))
@@ -319,6 +331,10 @@ def run_preprocess_pipeline(
                 return
             adapter, video_id, preprocess_job_id = db_context
 
+            # Avoid frequent DB reads here; rely on local cancel marker for responsiveness.
+            if is_local_cancel_requested(video_id):
+                raise PipelineCanceled("local_cancel")
+
             try:
                 if event_type == "new":
                     # 단일 항목 리스트로 감싸서 업로드 재활용
@@ -354,6 +370,11 @@ def run_preprocess_pipeline(
         def handle_audio_stt_chain() -> Dict[str, Any]:
             """Audio 추출 → STT를 체인으로 실행."""
             nonlocal stt_elapsed
+            if db_context:
+                adapter, video_id, _ = db_context
+                raise_if_cancel_requested(adapter, video_id)
+            else:
+                raise_if_cancel_requested(None, existing_video_id)
             from src.audio.stt_router import load_audio_settings
             audio_settings = load_audio_settings()
             extract_settings = audio_settings.get("extract", {})
@@ -391,6 +412,11 @@ def run_preprocess_pipeline(
         def handle_capture() -> List[Dict[str, Any]]:
             """캡처를 실행."""
             nonlocal capture_elapsed
+            if db_context:
+                adapter, video_id, _ = db_context
+                raise_if_cancel_requested(adapter, video_id)
+            else:
+                raise_if_cancel_requested(None, existing_video_id)
             pipeline_logger.log("Capture", "Extracting...")
             start = time.perf_counter()
             results = run_capture(
@@ -520,6 +546,41 @@ def run_preprocess_pipeline(
         print(f"Outputs: {rel_video_root}")
         print(f"Benchmark: {rel_report_path}")
         
+        if sync_to_db and db_context:
+            try:
+                _, video_id, _ = db_context
+                return video_id
+            except Exception:
+                pass
+        return None
+
+    except PipelineCanceled as exc:
+        # Canceled by user deletion request; exit quietly (no re-raise).
+        timer.end_total()
+        run_meta["ended_at_utc"] = datetime.now(timezone.utc).isoformat()
+        run_meta["status"] = "canceled"
+        run_meta["error"] = str(exc)
+        run_meta.setdefault("durations_sec", {})
+        run_meta["durations_sec"]["total_sec"] = round(timer.get_total_elapsed(), 6)
+        run_meta_path.write_text(
+            json.dumps(run_meta, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+        if sync_to_db and db_context:
+            try:
+                adapter, video_id, preprocess_job_id = db_context
+                finalize_preprocess_db_sync(
+                    adapter=adapter,
+                    video_id=video_id,
+                    preprocess_job_id=preprocess_job_id,
+                    run_meta=run_meta,
+                    errors=[f"canceled: {exc}"],
+                )
+            except Exception:
+                pass
+
+        print(f"\nPreprocessing canceled: {exc}")
         if sync_to_db and db_context:
             try:
                 _, video_id, _ = db_context

--- a/tests/test_storage_delete_fallback.py
+++ b/tests/test_storage_delete_fallback.py
@@ -63,6 +63,8 @@ class FakeAdapter:
         self.s3_client = None
         self.r2_only = r2_only
         self.deleted_videos = []
+        self.delete_marks = []
+        self.delete_clears = []
         self.removed = []
         self.videos = {
             video_id: {
@@ -83,6 +85,18 @@ class FakeAdapter:
 
     def get_video(self, video_id: str):
         return self.videos.get(video_id)
+
+    def mark_video_delete_requested(self, video_id: str, *, when_iso: str | None = None) -> bool:
+        self.delete_marks.append((video_id, when_iso))
+        if video_id in self.videos:
+            self.videos[video_id]["delete_requested_at"] = when_iso or "now"
+        return True
+
+    def clear_video_delete_requested(self, video_id: str) -> bool:
+        self.delete_clears.append(video_id)
+        if video_id in self.videos:
+            self.videos[video_id]["delete_requested_at"] = None
+        return True
 
     def delete_video(self, video_id: str, user_id: str) -> bool:
         self.deleted_videos.append((video_id, user_id))


### PR DESCRIPTION
## 변경사항
- 처리 중인 영상도 `DELETE /api/videos/{video_id}`로 삭제 가능하도록 409 차단 로직 제거
- 삭제 요청 시 파이프라인이 최대한 빨리 멈추도록 취소 신호(로컬 + DB 마커) 추가
- 전처리/처리/배치/async 파이프라인에 취소 체크포인트 반영
- 프론트: 삭제 409 전용 에러 처리 제거, SSE에서 404면 재시도 중단
- 테스트 업데이트 (삭제 관련)

## DB 반영 필요
Supabase에 아래 컬럼을 추가해야 cross-instance 취소 신호가 동작합니다.
```sql
alter table public.videos
add column if not exists delete_requested_at timestamptz;
```

## 테스트
- `pytest -q` 통과 (18 passed)
