### PR TITLE
feat: 요약 재시작 시 이어하기(resume) 지원

### DIFF
--- a/src/process_api.py
+++ b/src/process_api.py
@@ -106,6 +106,7 @@ class ProcessRequest(BaseModel):
     limit: Optional[int] = None
     force_db: Optional[bool] = None
     sync_to_db: Optional[bool] = None
+    resume: Optional[bool] = None
 
 
 class ProcessResponse(BaseModel):
@@ -143,6 +144,9 @@ def process_pipeline(
     if request.video_id and sync_to_db is None:
         sync_to_db = True
 
+    resume = request.resume
+    existing_processing_job_id: Optional[str] = None
+
     # video_id 기반 요청만 인증/권한 체크 (video_name-only는 기존 dev/local 사용을 위해 허용)
     if request.video_id:
         adapter = get_supabase_adapter()
@@ -162,6 +166,11 @@ def process_pipeline(
                 detail="Pipeline is already running for this video",
             )
 
+        if resume is None:
+            resume = (video.get("status") or "").upper() == "FAILED"
+        if resume:
+            existing_processing_job_id = video.get("current_processing_job_id")
+
         # 재시작/재실행 요청은 즉시 상태를 PROCESSING으로 전환하고 기존 오류를 클리어한다.
         # (SSE가 FAILED에서 즉시 종료되는 문제 및 stale error banner 방지)
         try:
@@ -178,6 +187,8 @@ def process_pipeline(
         limit=request.limit,
         force_db=request.force_db,
         sync_to_db=sync_to_db,
+        existing_processing_job_id=existing_processing_job_id,
+        resume=bool(resume),
     )
 
     return ProcessResponse(status="started", message="processing started")

--- a/tests/test_process_restart_status.py
+++ b/tests/test_process_restart_status.py
@@ -11,6 +11,7 @@ class FakeAdapter:
                 "user_id": "owner",
                 "status": "FAILED",
                 "error_message": "boom",
+                "current_processing_job_id": "pj1",
             }
         }
         self.update_calls = []
@@ -55,6 +56,8 @@ def test_process_restart_marks_processing_and_clears_error(monkeypatch):
     assert adapter.videos["v1"]["error_message"] is None
     assert pipeline_calls and pipeline_calls[0]["video_id"] == "v1"
     assert pipeline_calls[0]["sync_to_db"] is True
+    assert pipeline_calls[0]["resume"] is True
+    assert pipeline_calls[0]["existing_processing_job_id"] == "pj1"
 
 
 def test_process_blocks_duplicate_run(monkeypatch):

--- a/tests/test_summary_resume_helpers.py
+++ b/tests/test_summary_resume_helpers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.run_process_pipeline import (
+    _compute_skip_captures,
+    _detect_completed_batches,
+    _rebuild_fusion_accumulators,
+)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_detect_completed_batches_counts_consecutive_pass(tmp_path: Path) -> None:
+    video_root = tmp_path
+
+    # batch_1: PASS
+    _write_json(video_root / "batches" / "batch_1" / "judge.json", {"pass": True})
+    (video_root / "batches" / "batch_1" / "fusion").mkdir(parents=True, exist_ok=True)
+    (video_root / "batches" / "batch_1" / "fusion" / "segment_summaries.jsonl").write_text(
+        '{"segment_id": 1}\n', encoding="utf-8"
+    )
+    (video_root / "batches" / "batch_1" / "fusion" / "segments_units.jsonl").write_text(
+        '{"segment_id": 1}\n', encoding="utf-8"
+    )
+
+    # batch_2: PASS
+    _write_json(video_root / "batches" / "batch_2" / "judge.json", {"pass": True})
+    (video_root / "batches" / "batch_2" / "fusion").mkdir(parents=True, exist_ok=True)
+    (video_root / "batches" / "batch_2" / "fusion" / "segment_summaries.jsonl").write_text(
+        '{"segment_id": 2}\n', encoding="utf-8"
+    )
+    (video_root / "batches" / "batch_2" / "fusion" / "segments_units.jsonl").write_text(
+        '{"segment_id": 2}\n', encoding="utf-8"
+    )
+
+    # batch_3: FAIL (should stop here)
+    _write_json(video_root / "batches" / "batch_3" / "judge.json", {"pass": False})
+    (video_root / "batches" / "batch_3" / "fusion").mkdir(parents=True, exist_ok=True)
+    (video_root / "batches" / "batch_3" / "fusion" / "segment_summaries.jsonl").write_text(
+        '{"segment_id": 3}\n', encoding="utf-8"
+    )
+    (video_root / "batches" / "batch_3" / "fusion" / "segments_units.jsonl").write_text(
+        '{"segment_id": 3}\n', encoding="utf-8"
+    )
+
+    assert _detect_completed_batches(video_root) == 2
+
+
+def test_compute_skip_captures_uses_vlm_items(tmp_path: Path) -> None:
+    video_root = tmp_path
+
+    # batch_1: 4 captures
+    _write_json(
+        video_root / "batches" / "batch_1" / "vlm.json",
+        {"items": [{"i": 1}, {"i": 2}, {"i": 3}, {"i": 4}]},
+    )
+
+    # batch_2: 2 captures
+    _write_json(
+        video_root / "batches" / "batch_2" / "vlm.json",
+        {"items": [{"i": 1}, {"i": 2}]},
+    )
+
+    assert _compute_skip_captures(video_root, completed_batches=2, batch_size=4) == 6
+
+
+def test_rebuild_fusion_accumulators_concatenates_jsonl(tmp_path: Path) -> None:
+    video_root = tmp_path
+
+    b1 = video_root / "batches" / "batch_1" / "fusion"
+    b2 = video_root / "batches" / "batch_2" / "fusion"
+    b1.mkdir(parents=True, exist_ok=True)
+    b2.mkdir(parents=True, exist_ok=True)
+
+    (b1 / "segment_summaries.jsonl").write_text("a\n", encoding="utf-8")
+    (b1 / "segments_units.jsonl").write_text("u1\n", encoding="utf-8")
+
+    # no trailing newline on purpose to test newline normalization
+    (b2 / "segment_summaries.jsonl").write_text("b", encoding="utf-8")
+    (b2 / "segments_units.jsonl").write_text("u2", encoding="utf-8")
+
+    _rebuild_fusion_accumulators(video_root, completed_batches=2)
+
+    fusion_dir = video_root / "fusion"
+    assert (fusion_dir / "segment_summaries.jsonl").read_text(encoding="utf-8") == "a\nb\n"
+    assert (fusion_dir / "segments_units.jsonl").read_text(encoding="utf-8") == "u1\nu2\n"


### PR DESCRIPTION
## 변경 사항
- `POST /process`에 `resume` 플래그 추가 (기본: 비디오 상태가 `FAILED`면 resume).
- 실패 후 재시작 시 기존 `current_processing_job_id`를 재사용하여 **마지막 PASS 배치 다음 배치부터** 이어서 처리.
- `fusion/segment_summaries.jsonl`, `fusion/segments_units.jsonl` 누적 파일을 **완료 배치 기준으로 재구성**하여 중복 누적 방지.

## 테스트
- `pytest -q` (21 passed)

## 참고
- 프론트는 기존처럼 `POST /process { video_id, sync_to_db: true }` 호출만 해도, `FAILED` 상태에서 자동으로 이어하기가 동작합니다.