### PR TITLE
fix: 만료 토큰 자동 갱신 + 영상 목록 로딩 속도 개선

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
-import { getMediaTicket } from '../api/videos';
+import { getMediaTicket, invalidateVideosCache } from '../api/videos';
 
 const AuthContext = createContext();
 
@@ -54,21 +54,27 @@ export function AuthProvider({ children }) {
             return;
         }
 
-        // 현재 세션 확인 + 토큰 갱신
+        // 현재 세션 확인 → 먼저 기존 세션 사용자 세팅 후 백그라운드 refresh
         supabase.auth.getSession().then(async ({ data: { session } }) => {
-            let activeUser = null;
             if (session?.user) {
-                // 토큰이 있으면 실제 갱신 시도 (만료된 access_token 방지)
-                const { data, error } = await supabase.auth.refreshSession();
-                if (!error && data.session) {
-                    activeUser = data.session.user;
-                }
-                // refresh 실패 = refresh token 만료 → activeUser는 null 유지
-            }
-            setUser(activeUser);
-            setLoading(false);
-            if (activeUser) {
+                // 세션이 있으면 먼저 사용자 세팅 (네트워크 실패 시에도 로그아웃 안 됨)
+                setUser(session.user);
+                setLoading(false);
                 refreshMediaTicket();
+
+                // 백그라운드에서 토큰 갱신 시도
+                try {
+                    const { data, error } = await supabase.auth.refreshSession();
+                    if (!error && data.session?.user) {
+                        setUser(data.session.user);
+                    }
+                    // refresh 실패해도 기존 세션 유지 (onAuthStateChange가 만료 처리)
+                } catch {
+                    // 네트워크 일시 실패 — 기존 세션 유지
+                }
+            } else {
+                setUser(null);
+                setLoading(false);
             }
         });
 
@@ -79,6 +85,7 @@ export function AuthProvider({ children }) {
                 if (session?.user) {
                     refreshMediaTicket();
                 } else {
+                    invalidateVideosCache();
                     setMediaTicket(null);
                     setMediaTicketExpAt(0);
                     if (mediaTicketTimerRef.current) {

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -140,6 +140,7 @@ function HomePage() {
                                 <VideoCard
                                     id={video.id}
                                     title={video.name || video.original_filename}
+                                    thumbnail={video.thumbnail_url}
                                     thumbnailVideoId={video.id}
                                     duration={formatDuration(video.duration_sec)}
                                     date={formatDate(video.created_at)}

--- a/src/process_api.py
+++ b/src/process_api.py
@@ -44,6 +44,7 @@ GET 실행
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -67,6 +68,8 @@ from src.run_process_pipeline import run_processing_pipeline
 from src.services.chat_session_store import ChatSessionStore
 from src.pipeline.cancel import PipelineCanceled, raise_if_cancel_requested
 
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Screentime Processing API")
 
@@ -978,9 +981,10 @@ def list_videos(http_request: Request) -> Dict[str, Any]:
                 adapter.client.table("captures")
                 .select("video_id, storage_path")
                 .in_("video_id", video_ids)
+                .order("created_at", desc=False)
                 .execute()
             )
-            # video_id별 첫 번째 capture만 사용
+            # video_id별 첫 번째 capture만 사용 (created_at 기준 가장 이른 것)
             for row in caps.data or []:
                 vid = row.get("video_id")
                 if vid and vid not in thumb_map and row.get("storage_path"):
@@ -990,7 +994,7 @@ def list_videos(http_request: Request) -> Dict[str, Any]:
                     if signed:
                         thumb_map[vid] = signed
         except Exception:
-            pass
+            logger.exception("Failed to batch-fetch thumbnail URLs")
 
     for v in videos:
         v["thumbnail_url"] = thumb_map.get(v.get("id"), None)
@@ -1114,12 +1118,13 @@ def get_video_thumbnail(video_id: str, http_request: Request, ticket: Optional[s
     user_id = _require_user_id_from_request_or_ticket(adapter, http_request, ticket)
     video = _require_video_owner(adapter, user_id=user_id, video_id=video_id)
 
-    # DB에서 첫 번째 캡처의 storage_path 조회
+    # DB에서 첫 번째 캡처의 storage_path 조회 (created_at 기준)
     try:
         caps = (
             adapter.client.table("captures")
             .select("storage_path")
             .eq("video_id", video_id)
+            .order("created_at", desc=False)
             .limit(1)
             .execute()
         )
@@ -1130,10 +1135,10 @@ def get_video_thumbnail(video_id: str, http_request: Request, ticket: Optional[s
             if signed_url:
                 return RedirectResponse(
                     url=signed_url,
-                    headers={"Cache-Control": "public, max-age=1800"},
+                    headers={"Cache-Control": "private, max-age=1800"},
                 )
     except Exception:
-        pass
+        logger.exception("Failed to get thumbnail signed URL for video %s", video_id)
 
     # Fallback: 로컬 파일시스템
     video_name = video.get("name", "")


### PR DESCRIPTION
## Summary

Closes #208

- **401 자동 복구**: `client.js`에서 401 응답 시 `refreshSession()` 후 1회 자동 재시도. `AuthContext` 초기화 시 토큰 갱신을 보장하여 만료된 access_token 문제 해결
- **영상 목록 로딩 속도 개선**: `list_videos` API에서 captures 배치 조회로 `thumbnail_url` 일괄 포함, 프론트에서 N+1 개별 thumbnail 요청 제거
- **sessionStorage 캐시**: `listVideos()`에 1분 TTL 캐시 + 삭제/업로드 시 자동 무효화

### 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `frontend/src/api/client.js` | 401 시 `refreshSession()` + 재시도 (`request`, `postForm`) |
| `frontend/src/context/AuthContext.jsx` | 초기화 시 `refreshSession()` 호출로 토큰 갱신 보장 |
| `src/process_api.py` | `list_videos`에 captures 배치 조회 + `thumbnail_url`, thumbnail Cache-Control 추가 |
| `frontend/src/api/videos.js` | 백엔드 API 전환 + sessionStorage 캐시 |
| `frontend/src/pages/HomePage.jsx` | VideoCard에 `thumbnail` prop 전달 |

## Test plan

- [ ] DevTools에서 access_token을 임의 문자로 변경 → 새로고침 → 401 없이 자동 갱신되는지 확인
- [ ] 1시간 이상 방치 후 재접속 시 자동 로그인 + 정상 데이터 로딩 확인
- [ ] Network 탭에서 개별 `/thumbnail` 요청 없이 `/api/videos` 응답에 `thumbnail_url` 포함 확인
- [ ] 영상 삭제 후 목록 정상 갱신 확인
- [ ] 영상 업로드 후 목록에 즉시 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)