### PR TITLE
fix: 파일명 sanitize 불일치로 인한 캡처 스토리지 업로드 실패 수정

### DIFF
--- a/src/capture/process_content.py
+++ b/src/capture/process_content.py
@@ -33,6 +33,7 @@ def process_single_video_capture(
     min_interval: Optional[float] = None,
     write_manifest: bool = True,
     callback: Optional[Any] = None,
+    video_name_override: Optional[str] = None,
 ) -> List[dict]:
     """
     [Usage File]
@@ -55,13 +56,15 @@ def process_single_video_capture(
     - min_interval (Optional[float]): 미사용 (하위 호환용으로 시그니처에만 존재)
     - write_manifest (bool): 처리 완료 후 manifest.json 파일 생성 여부
     - callback (Optional[Any]): 슬라이드 감지 시 호출되는 콜백 ("new"/"update" 이벤트와 slide_data 전달)
+    - video_name_override (Optional[str]): output_base 하위 폴더명 강제 지정.
+      파이프라인이 sanitize한 video_name과 캡처 저장 폴더를 일치시키는 용도.
 
     [Returns]
     - List[dict]: 추출된 슬라이드들의 메타데이터 리스트 (id, file_name, time_ranges)
     """
     settings = get_capture_settings()
     video_path_obj = Path(video_path)
-    video_name = video_path_obj.stem
+    video_name = video_name_override or video_path_obj.stem
     
     # 출력 경로 설정: {output_base}/{video_name}/captures
     video_output_dir = Path(output_base) / video_name

--- a/src/pipeline/stages.py
+++ b/src/pipeline/stages.py
@@ -328,6 +328,7 @@ def run_capture(
     output_base: Path,
     *,
     threshold: float,
+    dedupe_threshold: Optional[float] = None,
     min_interval: float,
     verbose: bool,
     video_name: str,
@@ -337,6 +338,7 @@ def run_capture(
 ) -> List[Dict[str, Any]]:
     """슬라이드 캡처를 실행하고 메타데이터 목록을 반환한다."""
     # Note: dedup_enabled is ignored - new HybridSlideExtractor always uses pHash+ORB dedup
+    # Note: dedupe_threshold is ignored - dedup thresholds are configured via config/capture/settings.yaml
     metadata = process_single_video_capture(
         str(video_path),
         str(output_base),
@@ -344,6 +346,7 @@ def run_capture(
         min_interval=min_interval,
         write_manifest=write_manifest,
         callback=callback,
+        video_name_override=video_name,
     )
     return metadata
 

--- a/tests/test_capture_video_name_override.py
+++ b/tests/test_capture_video_name_override.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_run_capture_forwards_video_name_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from src.pipeline import stages
+
+    got: dict[str, object] = {}
+
+    def fake_process_single_video_capture(*args, **kwargs):
+        got.update(kwargs)
+        return [{"id": "cap_001", "file_name": "cap_001.jpg", "time_ranges": []}]
+
+    monkeypatch.setattr(stages, "process_single_video_capture", fake_process_single_video_capture)
+
+    out = stages.run_capture(
+        Path("C:/tmp/input.mp4"),
+        tmp_path,
+        threshold=0.1,
+        dedupe_threshold=42.0,
+        min_interval=0.5,
+        verbose=False,
+        video_name="sanitized_video_name",
+        write_manifest=False,
+    )
+
+    assert isinstance(out, list)
+    assert got.get("video_name_override") == "sanitized_video_name"
+
+
+def test_process_single_video_capture_uses_override_for_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from src.capture import process_content
+
+    fake_settings = SimpleNamespace(
+        persistence_drop_ratio=0.1,
+        sample_interval_sec=0.5,
+        persistence_threshold=10,
+        min_orb_features=200,
+        dedup_phash_threshold=8,
+        dedup_orb_distance=50,
+        dedup_sim_threshold=0.7,
+        enable_roi_detection=False,
+        roi_padding=0,
+        enable_smart_roi=False,
+        roi_warmup_frames=0,
+        enable_adaptive_resize=False,
+    )
+    monkeypatch.setattr(process_content, "get_capture_settings", lambda: fake_settings)
+
+    captured: dict[str, object] = {}
+
+    class FakeExtractor:
+        def __init__(self, *, video_path: str, output_dir: str, **kwargs) -> None:
+            captured["video_path"] = video_path
+            captured["output_dir"] = output_dir
+            captured["kwargs"] = kwargs
+
+        def process(self, *, video_name: str):
+            captured["process_video_name"] = video_name
+            return [{"id": "cap_001", "file_name": "cap_001.jpg", "time_ranges": []}]
+
+    monkeypatch.setattr(process_content, "HybridSlideExtractor", FakeExtractor)
+
+    results = process_content.process_single_video_capture(
+        video_path="C:/tmp/녹화_2022_05_08_16_49_55_421.mp4",
+        output_base=str(tmp_path),
+        write_manifest=True,
+        video_name_override="timestamp_2022_05_08_16_49_55_421",
+    )
+
+    assert isinstance(results, list)
+
+    expected_video_root = tmp_path / "timestamp_2022_05_08_16_49_55_421"
+    expected_captures_dir = expected_video_root / "captures"
+    expected_manifest = expected_video_root / "manifest.json"
+
+    assert expected_captures_dir.exists()
+    assert expected_manifest.exists()
+    assert captured.get("output_dir") == str(expected_captures_dir)
+    assert captured.get("process_video_name") == "timestamp_2022_05_08_16_49_55_421"
+


### PR DESCRIPTION
## 문제
특정 파일명(예: 한글 포함 / 선행 `_` / 연속 `_`)으로 업로드하면 로컬에는 캡처 이미지가 생성되지만 스토리지 업로드가 되지 않아 `captures.storage_path`가 NULL로 남고, 이후 VLM 단계가 연쇄 실패했습니다.

## 원인
- 파이프라인은 `video_path.stem`을 sanitize한 `video_name`으로 `video_root`를 생성합니다.
- 캡처 추출은 sanitize하지 않은 `video_path.stem`을 기준으로 `{output_base}/{stem}/captures`에 저장했습니다.
- 업로드 단계는 `{video_root}/captures`에서 파일을 찾기 때문에, sanitize 결과가 달라지면 캡처 파일을 찾지 못해 업로드가 스킵됩니다.
- 추가로 `run_capture()`가 `video_name` 인자를 받지만 캡처 구현으로 전달하지 않아(Dead parameter) 불일치를 해소할 수 없었습니다.

## 변경사항
- `process_single_video_capture()`에 `video_name_override` 인자 추가: 캡처 저장 폴더/Extractor 이름을 override 기준으로 일치
- `run_capture()`에서 `video_name_override=video_name`을 전달하도록 수정
- 호출부 호환을 위해 `run_capture()`에 `dedupe_threshold` kwarg를 추가(현재 로직에서는 미사용)
- 업로드 시 캡처 파일이 없을 때(경로 불일치 등) 요약 진단 로그 추가
- 단위 테스트 추가: forwarding + output-dir override

## 테스트
- `python -m pytest -q`

Closes #210