### PR TITLE
fix: 모바일/태블릿 UI 버그 수정 및 요약 패널 Bot 아이콘 통합

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -139,7 +139,7 @@ function Sidebar({ isOpen, onClose }) {
                 />
             )}
 
-            <aside className={`fixed lg:relative z-40 transition-all duration-300 ease-in-out pointer-events-none lg:pointer-events-auto
+            <aside className={`fixed lg:relative z-[95] transition-all duration-300 ease-in-out pointer-events-none lg:pointer-events-auto
                 /* Mobile: Full Screen Overlay */
                 inset-0 w-full
                 /* Desktop: Left Column with Padding for Gradient Effect */

--- a/frontend/src/components/SummaryPanel.jsx
+++ b/frontend/src/components/SummaryPanel.jsx
@@ -174,17 +174,37 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
                                 <span className="text-[var(--text-secondary)] text-[10px] font-medium opacity-70">
                                     {item.start_ms != null ? formatMs(item.start_ms) : '00:00'}
                                 </span>
+                                <div className="h-[4px]" />
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onAskChatBot?.({ segIdx, timeRange, content: item.summary });
+                                    }}
+                                    className="flex items-center justify-center w-6 h-6 rounded-full hover:bg-white/10 text-orange-500 transition-colors"
+                                    title="원본 분석 답변"
+                                >
+                                    <Bot size={20} />
+                                </button>
                             </div>
                         </div>
 
                         <div className="flex-1 min-w-0 px-4">
                             {/* Mobile: Center Title */}
                             <div className="lg:hidden flex items-center justify-center h-6 mb-1">
-                                <h4 className="text-[var(--text-primary)] font-semibold truncate text-center text-[15px]">
+                                <h4 className="text-[var(--text-primary)] font-semibold truncate text-center text-[15px] flex items-center gap-2">
                                     {title}
+                                    <button
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onAskChatBot?.({ segIdx, timeRange, content: item.summary });
+                                        }}
+                                        className="flex items-center justify-center w-6 h-6 rounded-full hover:bg-white/10 text-orange-500 transition-colors shrink-0"
+                                        title="원본 분석 답변"
+                                    >
+                                        <Bot size={20} />
+                                    </button>
                                 </h4>
                             </div>
-
                             {!hasSections && <p className="text-[var(--text-secondary)] text-[13px] italic">요약 데이터 준비 중...</p>}
 
                             {bullets.length > 0 && (
@@ -200,19 +220,6 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
                             )}
                         </div>
 
-                        {/* Action Buttons */}
-                        <div className="absolute right-2 top-0 flex items-center h-full opacity-0 group-hover:opacity-100 transition-opacity">
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAskChatBot?.({ segIdx, timeRange, content: item.summary });
-                                }}
-                                className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-white/10 text-[var(--text-secondary)] hover:text-blue-400 transition-colors"
-                                title="원본 분석 답변"
-                            >
-                                <Clock size={16} />
-                            </button>
-                        </div>
                     </div>
                 </div>
             );
@@ -232,7 +239,24 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
 
 
                 {/* 1. Top Header Row Info */}
-                <div className="flex flex-row items-center border-b border-[var(--border-color)]/30 pb-3 mb-4">
+                {/* Mobile/Tablet: Compact header matching simple view */}
+                <div className="lg:hidden flex items-center justify-center h-6 mb-1">
+                    <h4 className="text-[var(--text-primary)] font-semibold truncate text-center text-[15px] flex items-center gap-2">
+                        {title}
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onAskChatBot?.({ segIdx, timeRange, content: item.summary });
+                            }}
+                            className="flex items-center justify-center w-6 h-6 rounded-full hover:bg-white/10 text-orange-500 transition-colors"
+                            title="원본 분석 답변"
+                        >
+                            <Bot size={20} />
+                        </button>
+                    </h4>
+                </div>
+                {/* Desktop: Full header with Seg column */}
+                <div className="hidden lg:flex flex-row items-center border-b border-[var(--border-color)]/30 pb-3 mb-4">
                     <div className="w-[60px] shrink-0 border-r border-[var(--border-color)]/30 mr-4 self-stretch flex items-center justify-center">
                         <div className="flex flex-col items-center justify-center h-full">
                             <span className="text-[var(--text-primary)] font-bold text-[15px]">Seg {segIdx}</span>
@@ -249,7 +273,7 @@ function SummaryPanel({ isExpanded, onToggleExpand, videoId, onSeekTo, currentTi
                                 className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-white/10 text-orange-500 transition-colors ml-1"
                                 title="원본 분석 답변"
                             >
-                                <Bot size={24} />
+                                <Bot size={20} />
                             </button>
                         </h4>
                     </div>

--- a/frontend/src/pages/AnalysisPage.jsx
+++ b/frontend/src/pages/AnalysisPage.jsx
@@ -432,7 +432,7 @@ function AnalysisPage() {
                             <div ref={videoSectionRef} className="w-full max-w-[1024px] px-5 sm:px-8 mx-auto shrink-0 pt-6">
                                 <div
                                     className={scrollPip
-                                        ? `fixed z-50 aspect-video animate-pipSlideIn transition-all duration-300 hover:scale-[1.02] ${chatbotOpen ? 'right-[calc(1.5rem+var(--chatbot-width))]' : 'right-6'} top-[58px] w-80 lg:top-auto lg:bottom-6 lg:w-96 rounded-xl overflow-hidden border border-[var(--border-color)] shadow-2xl`
+                                        ? `fixed z-50 aspect-video animate-pipSlideIn transition-all duration-300 hover:scale-[1.02] right-6 ${chatbotOpen ? 'lg:right-[calc(1.5rem+var(--chatbot-width))]' : 'lg:right-6'} top-[58px] w-80 md:w-96 lg:top-auto lg:bottom-6 lg:w-96 rounded-xl overflow-hidden border border-[var(--border-color)] shadow-2xl`
                                         : "relative w-full aspect-video border-b border-[var(--border-color)] bg-black shadow-sm"}
                                 >
                                     <VideoPlayer


### PR DESCRIPTION
  ## Summary

- 모바일 사이드바 z-index 수정으로 오버레이 뒤에 가려지던 문제 해결
- 요약 패널 Bot 아이콘을 주황색 20px로 통일하고 간단히/상세보기 모두 인라인 배치
- 상세보기 모바일 헤더를 간단히 보기와 동일한 스타일(15px, h-6, 중앙 정렬)로 반응형 분리
- PiP 영상 태블릿 크기 확대 및 모바일 챗봇 열림 시 화면 밖 렌더링 버그 수정

## Changes

    파일: Sidebar.jsx
    변경 내용: z-index z-40 → z-[95] (오버레이 z-[90] 위로)
    ────────────────────────────────────────
    파일: SummaryPanel.jsx
    변경 내용: Bot 아이콘 주황색 20px 통일, 모바일/데스크톱 반응형 헤더 분리, Seg 컬럼 내 Bot 배치
    ────────────────────────────────────────
    파일: AnalysisPage.jsx
    변경 내용: PiP 태블릿 md:w-96 추가, 모바일 챗봇 열림 시 right-6 고정
    Test plan

- 모바일에서 햄버거 메뉴 사이드바 열었을 때 콘텐츠가 선명하게 보이는지 확인
- 간단히 보기/상세보기 모두 주황색 Bot 아이콘이 정상 표시되는지 확인
- 태블릿에서 PiP 영상 크기가 적절한지 확인
- 모바일에서 챗봇 열린 상태로 PiP 영상이 화면 내에 표시되는지 확인
